### PR TITLE
Add cogify method

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,6 @@ COPY environment.yml /tmp/environment.yml
 RUN conda env update -f /tmp/environment.yml -n base && rm /tmp/environment.yml
 
 COPY . /tmp/stactools-modis
-RUN cd /tmp/stactools-modis && pip install . && rm -rf /tmp/stactools-modis
+RUN cd /tmp/stactools-modis && pip install . --no-binary rasterio && rm -rf /tmp/stactools-modis
 
 ENTRYPOINT [ "python", "-m", "stactools.cli" ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,3 +7,6 @@ explicit_package_bases = True
 
 [mypy-shapely.*]
 ignore_missing_imports = True
+
+[mypy-rasterio.*]
+ignore_missing_imports = True

--- a/scripts/update
+++ b/scripts/update
@@ -18,7 +18,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         python -m pip install --upgrade pip
-        pip install .
+        pip install . --no-binary rasterio
         pip install -r requirements-dev.txt
     fi
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ keywords =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -3,6 +3,7 @@ import os
 from typing import Optional
 
 import pystac
+import rasterio
 from pystac import Item
 import stactools.core.utils.convert
 
@@ -54,3 +55,19 @@ def create_cogs(item: Item, cog_directory: Optional[str] = None) -> None:
                          title='Raster Dataset')
 
     item.assets[ITEM_COG_IMAGE_NAME] = asset
+
+
+def cogify(infile: str, outdir: str) -> None:
+    """Creates cogs for the provided HDF file.
+
+    This will create one COG per subdataset in the HDF file.
+    """
+    with rasterio.open(infile) as dataset:
+        subdatasets = dataset.subdatasets
+    base_file_name = os.path.splitext(os.path.basename(infile))[0]
+    for subdataset in subdatasets:
+        parts = subdataset.split(":")
+        product = parts[-1]
+        file_name = f"{base_file_name}_{product}.tif"
+        outfile = os.path.join(outdir, file_name)
+        stactools.core.utils.convert.cogify(subdataset, outfile)

--- a/src/stactools/modis/commands.py
+++ b/src/stactools/modis/commands.py
@@ -50,4 +50,11 @@ def create_modis_command(cli: Group) -> Command:
 
         item.save_object()
 
+    @modis.command("cogify")
+    @click.argument("infile")
+    @click.argument("outdir")
+    def cogify_command(infile: str, outdir: str) -> None:
+        """Converts a MODIS HDF file into one or more cloud optimized GeoTIFFs (COGs)."""
+        cog.cogify(infile, outdir)
+
     return modis

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -1,0 +1,29 @@
+import os.path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from stactools.modis import cog
+
+from tests import test_data
+
+
+class CogTest(TestCase):
+
+    def test_cogify(self) -> None:
+        infile = test_data.get_path(
+            "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf")
+        with TemporaryDirectory() as temporary_directory:
+            cog.cogify(infile, temporary_directory)
+            file_names = os.listdir(temporary_directory)
+        self.assertEqual(len(file_names), 13)
+        subdataset_names = [
+            "LC_Type1", "LC_Type2", "LC_Type3", "LC_Type4", "LC_Type5",
+            "LC_Prop1_Assessment", "LC_Prop2_Assessment",
+            "LC_Prop3_Assessment", "LC_Prop1", "LC_Prop2", "LC_Prop3", "QC",
+            "LW"
+        ]
+        expected_cog_names = [
+            f"MCD12Q1.A2001001.h00v08.006.2018142182903_{subdataset_name}.tif"
+            for subdataset_name in subdataset_names
+        ]
+        self.assertEqual(set(file_names), set(expected_cog_names))


### PR DESCRIPTION
This method (and command-line utility) creates a single Cloud Optimized GeoTIFF (COG) for each variable in the HDF file. I've spot-checked this with some 6.0 and 6.1 products and seems to work fine afaict.