### PR TITLE
Adds a pull request template, and downgrades package version to v0.1.0 (unreleased)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,11 @@
+**Related Issue(s):** Please add links (if any) to related github issues.
+
+**Description:** Please explain the changes you made here.
+
+**PR checklist:**
+
+- [ ] Code is formatted (run `scripts/format`).
+- [ ] Code lints properly (run `scripts/lint`).
+- [ ] Tests pass (run `scripts/test`).
+- [ ] Documentation has been updated to reflect changes, if applicable.
+- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Everything

--- a/src/stactools/modis/__init__.py
+++ b/src/stactools/modis/__init__.py
@@ -12,7 +12,7 @@ def register_plugin(registry: Registry) -> None:
     registry.register_subcommand(commands.create_modis_command)
 
 
-__version__ = "0.1.3"
+__version__ = "0.1.0"
 """Library version"""
 
 __all__ = ["create_item", "create_cogs"]


### PR DESCRIPTION
Adds a pull request template from stactools-packages/template.

Also adds a changlog, and since there isn't anything on PyPI, no CHANGELOG, no tags, and no Github releases, I think it's safe to downgrade the version in `__init__.py` to v0.1.0 and set up this package as "unreleased" for now.