### PR TITLE
Fix asset HREFs and cogification

### DIFF
--- a/scripts/create_expected.py
+++ b/scripts/create_expected.py
@@ -25,4 +25,5 @@ for file_name in os.listdir(data_files_directory):
         item.validate()
 
         collection.add_item(item)
+        collection.make_all_asset_hrefs_relative()
         collection.save(catalog_type=CatalogType.SELF_CONTAINED)

--- a/src/stactools/modis/__init__.py
+++ b/src/stactools/modis/__init__.py
@@ -1,7 +1,6 @@
 import stactools.core
 from stactools.cli.registry import Registry
 
-from stactools.modis.cog import create_cogs
 from stactools.modis.stac import create_item
 
 stactools.core.use_fsspec()
@@ -15,4 +14,4 @@ def register_plugin(registry: Registry) -> None:
 __version__ = "0.1.0"
 """Library version"""
 
-__all__ = ["create_item", "create_cogs"]
+__all__ = ["create_item"]

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -2,22 +2,11 @@ import logging
 import os
 from typing import List, Optional
 
-import pystac
 import rasterio
 import stactools.core.utils.convert
 from pystac import Item
 
-from stactools.modis.constants import ITEM_COG_IMAGE_NAME, ITEM_TIF_IMAGE_NAME
-
 logger = logging.getLogger(__name__)
-
-
-def _create_cog(item: Item, cog_directory: str) -> str:
-    hdf_asset = item.assets.get(ITEM_TIF_IMAGE_NAME)
-    assert hdf_asset
-    stactools.core.utils.convert.cogify(hdf_asset.href, cog_directory)
-
-    return cog_directory
 
 
 def create_cogs(item: Item, cog_directory: Optional[str] = None) -> None:
@@ -36,24 +25,7 @@ def create_cogs(item: Item, cog_directory: Optional[str] = None) -> None:
         pystac.Item: The same item, mutated to include assets for the
             new COGs.
     """
-    file_name = f"{item.id}-cog.tif"
-    if cog_directory:
-        cog_href = os.path.join(cog_directory, file_name)
-    else:
-        item_href = item.get_self_href()
-        if not item_href:
-            raise ValueError(
-                "COG directory not provided, and item has no self href")
-        cog_href = os.path.join(item_href, file_name)
-
-    _create_cog(item, cog_href)
-
-    asset = pystac.Asset(href=cog_href,
-                         media_type=pystac.MediaType.COG,
-                         roles=["data"],
-                         title="Raster Dataset")
-
-    item.assets[ITEM_COG_IMAGE_NAME] = asset
+    raise NotImplementedError
 
 
 def cogify(infile: str, outdir: str) -> List[str]:

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from typing import List, Optional, Tuple
 
 import rasterio
@@ -67,8 +68,10 @@ def cogify(infile: str, outdir: str) -> Tuple[List[str], List[str]]:
             - The first element is a list of the output tif paths
             - The second element is a list of subdataset names
     """
-    with rasterio.open(infile) as dataset:
-        subdatasets = dataset.subdatasets
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
+        with rasterio.open(infile) as dataset:
+            subdatasets = dataset.subdatasets
     base_file_name = os.path.splitext(os.path.basename(infile))[0]
     paths = []
     subdataset_names = []

--- a/src/stactools/modis/commands.py
+++ b/src/stactools/modis/commands.py
@@ -39,7 +39,7 @@ def create_modis_command(cli: Group) -> Command:
         item_path = os.path.join(outdir, "{}.json".format(item.id))
         item.set_self_href(item_path)
         if cogify:
-            cog.create_cogs(item)
+            cog.add_cogs(item)
         item.validate()
         item.save_object()
 

--- a/src/stactools/modis/constants.py
+++ b/src/stactools/modis/constants.py
@@ -1,3 +1,2 @@
-ITEM_COG_IMAGE_NAME = "cog_image"
-ITEM_TIF_IMAGE_NAME = "tif_image"
-ITEM_METADATA_NAME = "metadata"
+HDF_ASSET = "hdf"
+METADATA_ASSET = "metadata"

--- a/src/stactools/modis/fragments/MCD12Q1/006/collection.json
+++ b/src/stactools/modis/fragments/MCD12Q1/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/101/MCD12_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MCD12Q1",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MCD43A4/006/collection.json
+++ b/src/stactools/modis/fragments/MCD43A4/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://www.umb.edu/spectralmass/terra_aqua_modis/v006",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://doi.org/10.5067/MODIS/MCD43A2.006",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD10A1/006/collection.json
+++ b/src/stactools/modis/fragments/MOD10A1/006/collection.json
@@ -1,12 +1,7 @@
 {
     "links": [
         {
-            "rel": "item",
-            "href": "https://doi.org/10.5067/MODIS/MOD10A1.006",
-            "title": "Documentation"
-        },
-        {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://doi.org/10.5067/MODIS/MOD10A1.006",
             "title": "Hall, D. K., V. V. Salomonson, and G. A. Riggs. 2016. MODIS/Terra Snow Cover Daily L3 Global 500m Grid. Version 6. Boulder, Colorado USA: NASA National Snow and Ice Data Center Distributed Active Archive Center."
         }

--- a/src/stactools/modis/fragments/MOD11A1/006/collection.json
+++ b/src/stactools/modis/fragments/MOD11A1/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/118/MOD11_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD11A1",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD11A2/006/collection.json
+++ b/src/stactools/modis/fragments/MOD11A2/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/118/MOD11_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD11A2",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD13A1/006/collection.json
+++ b/src/stactools/modis/fragments/MOD13A1/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/103/MOD13_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD13A1",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD13Q1/006/collection.json
+++ b/src/stactools/modis/fragments/MOD13Q1/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/103/MOD13_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD13A2",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD14A1/006/collection.json
+++ b/src/stactools/modis/fragments/MOD14A1/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/88/MOD14_User_Guide_v6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD14A1",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD14A2/006/collection.json
+++ b/src/stactools/modis/fragments/MOD14A2/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/876/MOD14_User_Guide_v6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD14A2",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD15A2H/006/collection.json
+++ b/src/stactools/modis/fragments/MOD15A2H/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/624/MOD15_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD15A2H",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD16A3GF/006/collection.json
+++ b/src/stactools/modis/fragments/MOD16A3GF/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/494/MOD16_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD16A3GF",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD17A2H/006/collection.json
+++ b/src/stactools/modis/fragments/MOD17A2H/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/495/MOD17_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD17A2H",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD17A2HGF/006/collection.json
+++ b/src/stactools/modis/fragments/MOD17A2HGF/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/495/MOD17_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD17A2HGF",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD17A3HGF/006/collection.json
+++ b/src/stactools/modis/fragments/MOD17A3HGF/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/495/MOD17_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD17A3HGF",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD21A2/006/collection.json
+++ b/src/stactools/modis/fragments/MOD21A2/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/108/MOD21_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD21A2",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD44B/006/collection.json
+++ b/src/stactools/modis/fragments/MOD44B/006/collection.json
@@ -1,12 +1,12 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/112/MOD44B_User_Guide_V6.pdf",
             "title": "User Guide"
         },
         {
-            "rel": "item",
+            "rel": "describedby",
             "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD44B",
             "title": "Data File"
         }

--- a/src/stactools/modis/fragments/MOD44W/006/collection.json
+++ b/src/stactools/modis/fragments/MOD44W/006/collection.json
@@ -1,7 +1,7 @@
 {
     "links": [
         {
-            "rel": "item",
+            "rel": "help",
             "href": "https://lpdaac.usgs.gov/documents/109/MOD44W_User_Guide_ATBD_V6.pdf",
             "title": "User Guide"
         }

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -8,7 +8,7 @@ from pystac.utils import str_to_datetime
 from shapely.geometry import shape
 
 import stactools.modis.fragment
-from stactools.modis.constants import ITEM_METADATA_NAME, ITEM_TIF_IMAGE_NAME
+from stactools.modis.constants import HDF_ASSET, METADATA_ASSET
 from stactools.modis.file import File
 
 
@@ -133,22 +133,22 @@ def create_item(infile: str) -> Item:
 
     # Hdf
     item.add_asset(
-        ITEM_TIF_IMAGE_NAME,
+        HDF_ASSET,
         pystac.Asset(href=image_name.text,
                      media_type=pystac.MediaType.HDF,
                      roles=["data"],
-                     title="hdf image"))
+                     title="hdf data"))
 
     # Metadata
     item.add_asset(
-        ITEM_METADATA_NAME,
+        METADATA_ASSET,
         pystac.Asset(href=image_name.text + ".xml",
                      media_type=pystac.MediaType.TEXT,
                      roles=["metadata"],
                      title="FGDC Metdata"))
 
     # Bands
-    eo = EOExtension.ext(item.assets[ITEM_TIF_IMAGE_NAME], add_if_missing=True)
+    eo = EOExtension.ext(item.assets[HDF_ASSET], add_if_missing=True)
     eo.bands = [
         Band(band)
         for band in stactools.modis.fragment.load_bands(product, version)

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -135,7 +135,7 @@ def create_item(infile: str) -> Item:
     item.add_asset(
         HDF_ASSET,
         pystac.Asset(href=image_name.text,
-                     media_type=pystac.MediaType.HDF,
+                     media_type=MediaType.HDF,
                      roles=["data"],
                      title="hdf data"))
 
@@ -143,7 +143,7 @@ def create_item(infile: str) -> Item:
     item.add_asset(
         METADATA_ASSET,
         pystac.Asset(href=image_name.text + ".xml",
-                     media_type=pystac.MediaType.TEXT,
+                     media_type=MediaType.XML,
                      roles=["metadata"],
                      title="FGDC Metdata"))
 

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -134,7 +134,7 @@ def create_item(infile: str) -> Item:
     # Hdf
     item.add_asset(
         HDF_ASSET,
-        pystac.Asset(href=image_name.text,
+        pystac.Asset(href=file.hdf_path,
                      media_type=MediaType.HDF,
                      roles=["data"],
                      title="hdf data"))
@@ -142,7 +142,7 @@ def create_item(infile: str) -> Item:
     # Metadata
     item.add_asset(
         METADATA_ASSET,
-        pystac.Asset(href=image_name.text + ".xml",
+        pystac.Asset(href=file.xml_path,
                      media_type=MediaType.XML,
                      roles=["metadata"],
                      title="FGDC Metdata"))

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -166,13 +166,13 @@
       "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid"
@@ -180,7 +180,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
+      "href": "../../../../MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -242,7 +242,7 @@
       ]
     },
     "metadata": {
-      "href": "MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml",
+      "href": "../../../../MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -179,10 +179,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "LC_Type1",

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -243,7 +243,7 @@
     },
     "metadata": {
       "href": "MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MCD12Q1/006/collection.json
+++ b/tests/data-files/expected/MCD12Q1/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/101/MCD12_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MCD12Q1",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -52,13 +52,13 @@
       "title": "MCD43A4 v006 MODIS/Terra+Aqua Nadir BRDF-Adjusted Reflectance (NBAR) Daily L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MCD43A4 v006 MODIS/Terra+Aqua Nadir BRDF-Adjusted Reflectance (NBAR) Daily L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MCD43A4 v006 MODIS/Terra+Aqua Nadir BRDF-Adjusted Reflectance (NBAR) Daily L3 Global 500 m SIN Grid"
@@ -66,7 +66,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
+      "href": "../../../../MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -145,7 +145,7 @@
       ]
     },
     "metadata": {
-      "href": "MCD43A4.A2022019.h10v04.006.2022028111747.hdf.xml",
+      "href": "../../../../MCD43A4.A2022019.h10v04.006.2022028111747.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -146,7 +146,7 @@
     },
     "metadata": {
       "href": "MCD43A4.A2022019.h10v04.006.2022028111747.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -65,10 +65,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Nadir_Reflectance_Band1",

--- a/tests/data-files/expected/MCD43A4/006/collection.json
+++ b/tests/data-files/expected/MCD43A4/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MCD43A4 v006 MODIS/Terra+Aqua Nadir BRDF-Adjusted Reflectance (NBAR) Daily L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://www.umb.edu/spectralmass/terra_aqua_modis/v006",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://doi.org/10.5067/MODIS/MCD43A2.006",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -65,10 +65,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "NDSI_Snow_Cover",

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -105,7 +105,7 @@
     },
     "metadata": {
       "href": "MOD10A1.A2022029.h10v05.006.2022031045818.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -52,13 +52,13 @@
       "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6"
@@ -66,7 +66,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
+      "href": "../../../../MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -104,7 +104,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD10A1.A2022029.h10v05.006.2022031045818.hdf.xml",
+      "href": "../../../../MOD10A1.A2022029.h10v05.006.2022031045818.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD10A1/006/collection.json
+++ b/tests/data-files/expected/MOD10A1/006/collection.json
@@ -11,12 +11,7 @@
       "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6"
     },
     {
-      "rel": "item",
-      "href": "https://doi.org/10.5067/MODIS/MOD10A1.006",
-      "title": "Documentation"
-    },
-    {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://doi.org/10.5067/MODIS/MOD10A1.006",
       "title": "Hall, D. K., V. V. Salomonson, and G. A. Riggs. 2016. MODIS/Terra Snow Cover Daily L3 Global 500m Grid. Version 6. Boulder, Colorado USA: NASA National Snow and Ice Data Center Distributed Active Archive Center."
     },

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -141,7 +141,7 @@
     },
     "metadata": {
       "href": "MOD11A1.A2022030.h10v05.006.2022031094827.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -68,13 +68,13 @@
       "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid"
@@ -82,7 +82,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
+      "href": "../../../../MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -140,7 +140,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD11A1.A2022030.h10v05.006.2022031094827.hdf.xml",
+      "href": "../../../../MOD11A1.A2022030.h10v05.006.2022031094827.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -81,10 +81,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "LST_Day_1km",

--- a/tests/data-files/expected/MOD11A1/006/collection.json
+++ b/tests/data-files/expected/MOD11A1/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/118/MOD11_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD11A1",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -81,10 +81,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "LST_Day_1km",

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -68,13 +68,13 @@
       "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid"
@@ -82,7 +82,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
+      "href": "../../../../MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -140,7 +140,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD11A2.A2022017.h10v05.006.2022026205724.hdf.xml",
+      "href": "../../../../MOD11A2.A2022017.h10v05.006.2022026205724.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -141,7 +141,7 @@
     },
     "metadata": {
       "href": "MOD11A2.A2022017.h10v05.006.2022026205724.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD11A2/006/collection.json
+++ b/tests/data-files/expected/MOD11A2/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/118/MOD11_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD11A2",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -106,10 +106,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "500m 16 days NDVI",

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -170,7 +170,7 @@
     },
     "metadata": {
       "href": "MOD13A1.A2022001.h09v05.006.2022018175631.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -93,13 +93,13 @@
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid"
@@ -107,7 +107,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
+      "href": "../../../../MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -169,7 +169,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD13A1.A2022001.h09v05.006.2022018175631.hdf.xml",
+      "href": "../../../../MOD13A1.A2022001.h09v05.006.2022018175631.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD13A1/006/collection.json
+++ b/tests/data-files/expected/MOD13A1/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/103/MOD13_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD13A1",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -170,7 +170,7 @@
     },
     "metadata": {
       "href": "MOD13Q1.A2022001.h09v05.006.2022018175746.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -106,10 +106,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "250m 16 days NDVI",

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -93,13 +93,13 @@
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid"
@@ -107,7 +107,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
+      "href": "../../../../MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -169,7 +169,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD13Q1.A2022001.h09v05.006.2022018175746.hdf.xml",
+      "href": "../../../../MOD13Q1.A2022001.h09v05.006.2022018175746.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD13Q1/006/collection.json
+++ b/tests/data-files/expected/MOD13Q1/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/103/MOD13_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD13A2",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -68,13 +68,13 @@
       "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid"
@@ -82,7 +82,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
+      "href": "../../../../MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -108,7 +108,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD14A1.A2022017.h10v05.006.2022026155645.hdf.xml",
+      "href": "../../../../MOD14A1.A2022017.h10v05.006.2022026155645.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -109,7 +109,7 @@
     },
     "metadata": {
       "href": "MOD14A1.A2022017.h10v05.006.2022026155645.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -81,10 +81,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "FireMask",

--- a/tests/data-files/expected/MOD14A1/006/collection.json
+++ b/tests/data-files/expected/MOD14A1/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/88/MOD14_User_Guide_v6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD14A1",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -101,7 +101,7 @@
     },
     "metadata": {
       "href": "MOD14A2.A2022017.h10v05.006.2022026155645.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -68,13 +68,13 @@
       "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid"
@@ -82,7 +82,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
+      "href": "../../../../MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -100,7 +100,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD14A2.A2022017.h10v05.006.2022026155645.hdf.xml",
+      "href": "../../../../MOD14A2.A2022017.h10v05.006.2022026155645.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -81,10 +81,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "FireMask",

--- a/tests/data-files/expected/MOD14A2/006/collection.json
+++ b/tests/data-files/expected/MOD14A2/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/876/MOD14_User_Guide_v6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD14A2",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -116,7 +116,7 @@
     },
     "metadata": {
       "href": "MOD15A2H.A2022017.h10v05.006.2022026205820.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -67,13 +67,13 @@
       "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid"
@@ -81,7 +81,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
+      "href": "../../../../MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -115,7 +115,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD15A2H.A2022017.h10v05.006.2022026205820.hdf.xml",
+      "href": "../../../../MOD15A2H.A2022017.h10v05.006.2022026205820.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -80,10 +80,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Fpar_500m",

--- a/tests/data-files/expected/MOD15A2H/006/collection.json
+++ b/tests/data-files/expected/MOD15A2H/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/624/MOD15_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD15A2H",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -73,13 +73,13 @@
       "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid"
@@ -87,7 +87,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
+      "href": "../../../../MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -117,7 +117,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf.xml",
+      "href": "../../../../MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -86,10 +86,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "ET_500m",

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -118,7 +118,7 @@
     },
     "metadata": {
       "href": "MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD16A3GF/006/collection.json
+++ b/tests/data-files/expected/MOD16A3GF/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/494/MOD16_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD16A3GF",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -74,13 +74,13 @@
       "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN"
@@ -88,7 +88,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
+      "href": "../../../../MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -110,7 +110,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD17A2H.A2022017.h09v04.006.2022026222424.hdf.xml",
+      "href": "../../../../MOD17A2H.A2022017.h09v04.006.2022026222424.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -111,7 +111,7 @@
     },
     "metadata": {
       "href": "MOD17A2H.A2022017.h09v04.006.2022026222424.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -87,10 +87,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Gpp_500m",

--- a/tests/data-files/expected/MOD17A2H/006/collection.json
+++ b/tests/data-files/expected/MOD17A2H/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/495/MOD17_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD17A2H",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -87,10 +87,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Gpp_500m",

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -111,7 +111,7 @@
     },
     "metadata": {
       "href": "MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -74,13 +74,13 @@
       "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid"
@@ -88,7 +88,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
+      "href": "../../../../MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -110,7 +110,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf.xml",
+      "href": "../../../../MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD17A2HGF/006/collection.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/495/MOD17_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD17A2HGF",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -99,7 +99,7 @@
     },
     "metadata": {
       "href": "MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -66,13 +66,13 @@
       "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid"
@@ -80,7 +80,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
+      "href": "../../../../MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -98,7 +98,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf.xml",
+      "href": "../../../../MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -79,10 +79,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Npp_500m",

--- a/tests/data-files/expected/MOD17A3HGF/006/collection.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/495/MOD17_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD17A3HGF",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -153,7 +153,7 @@
     },
     "metadata": {
       "href": "MOD21A2.A2005361.h10v04.006.2018286181506.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -97,10 +97,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "LST_Day_1KM",

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -84,13 +84,13 @@
       "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid"
@@ -98,7 +98,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
+      "href": "../../../../MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -152,7 +152,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD21A2.A2005361.h10v04.006.2018286181506.hdf.xml",
+      "href": "../../../../MOD21A2.A2005361.h10v04.006.2018286181506.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD21A2/006/collection.json
+++ b/tests/data-files/expected/MOD21A2/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/108/MOD21_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD21A2",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -121,7 +121,7 @@
     },
     "metadata": {
       "href": "MOD44B.A2020065.h09v04.006.2021155155636.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -68,13 +68,13 @@
       "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid"
@@ -82,7 +82,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD44B.A2020065.h09v04.006.2021155155636.hdf",
+      "href": "../../../../MOD44B.A2020065.h09v04.006.2021155155636.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -120,7 +120,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD44B.A2020065.h09v04.006.2021155155636.hdf.xml",
+      "href": "../../../../MOD44B.A2020065.h09v04.006.2021155155636.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -81,10 +81,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD44B.A2020065.h09v04.006.2021155155636.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Percent_Tree_Cover",

--- a/tests/data-files/expected/MOD44B/006/collection.json
+++ b/tests/data-files/expected/MOD44B/006/collection.json
@@ -11,12 +11,12 @@
       "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/112/MOD44B_User_Guide_V6.pdf",
       "title": "User Guide"
     },
     {
-      "rel": "item",
+      "rel": "describedby",
       "href": "https://ladsweb.modaps.eosdis.nasa.gov/filespec/MODIS/6/MOD44B",
       "title": "Data File"
     },

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -77,10 +77,10 @@
     }
   ],
   "assets": {
-    "tif_image": {
+    "hdf": {
       "href": "MOD44W.A2015001.h10v04.006.2018033150244.hdf",
       "type": "application/x-hdf",
-      "title": "hdf image",
+      "title": "hdf data",
       "eo:bands": [
         {
           "name": "Water_mask",

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -97,7 +97,7 @@
     },
     "metadata": {
       "href": "MOD44W.A2015001.h10v04.006.2018033150244.hdf.xml",
-      "type": "text/plain",
+      "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [
         "metadata"

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -64,13 +64,13 @@
       "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid"
     },
     {
-      "rel": "parent",
+      "rel": "collection",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid"
     },
     {
-      "rel": "collection",
+      "rel": "parent",
       "href": "../collection.json",
       "type": "application/json",
       "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid"
@@ -78,7 +78,7 @@
   ],
   "assets": {
     "hdf": {
-      "href": "MOD44W.A2015001.h10v04.006.2018033150244.hdf",
+      "href": "../../../../MOD44W.A2015001.h10v04.006.2018033150244.hdf",
       "type": "application/x-hdf",
       "title": "hdf data",
       "eo:bands": [
@@ -96,7 +96,7 @@
       ]
     },
     "metadata": {
-      "href": "MOD44W.A2015001.h10v04.006.2018033150244.hdf.xml",
+      "href": "../../../../MOD44W.A2015001.h10v04.006.2018033150244.hdf.xml",
       "type": "application/xml",
       "title": "FGDC Metdata",
       "roles": [

--- a/tests/data-files/expected/MOD44W/006/collection.json
+++ b/tests/data-files/expected/MOD44W/006/collection.json
@@ -11,7 +11,7 @@
       "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid"
     },
     {
-      "rel": "item",
+      "rel": "help",
       "href": "https://lpdaac.usgs.gov/documents/109/MOD44W_User_Guide_ATBD_V6.pdf",
       "title": "User Guide"
     },

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -2,27 +2,43 @@ import os.path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from stactools.modis import cog
+from pystac import MediaType
+
+import stactools.modis.cog
+import stactools.modis.stac
 from tests import test_data
+
+SUBDATASET_NAMES = [
+    "LC_Type1", "LC_Type2", "LC_Type3", "LC_Type4", "LC_Type5",
+    "LC_Prop1_Assessment", "LC_Prop2_Assessment", "LC_Prop3_Assessment",
+    "LC_Prop1", "LC_Prop2", "LC_Prop3", "QC", "LW"
+]
 
 
 class CogTest(TestCase):
+
+    def test_cog(self) -> None:
+        infile = test_data.get_path(
+            "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf")
+        item = stactools.modis.stac.create_item(infile)
+        with TemporaryDirectory() as temporary_directory:
+            stactools.modis.cog.add_cogs(item, temporary_directory)
+        for subdataset_name in SUBDATASET_NAMES:
+            asset = item.assets[subdataset_name]
+            assert os.path.basename(
+                asset.href
+            ) == f"MCD12Q1.A2001001.h00v08.006.2018142182903_{subdataset_name}.tif"
+            assert asset.media_type == MediaType.COG
 
     def test_cogify(self) -> None:
         infile = test_data.get_path(
             "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf")
         with TemporaryDirectory() as temporary_directory:
-            paths = cog.cogify(infile, temporary_directory)
+            paths, _ = stactools.modis.cog.cogify(infile, temporary_directory)
         self.assertEqual(len(paths), 13)
         file_names = [os.path.basename(path) for path in paths]
-        subdataset_names = [
-            "LC_Type1", "LC_Type2", "LC_Type3", "LC_Type4", "LC_Type5",
-            "LC_Prop1_Assessment", "LC_Prop2_Assessment",
-            "LC_Prop3_Assessment", "LC_Prop1", "LC_Prop2", "LC_Prop3", "QC",
-            "LW"
-        ]
         expected_cog_names = [
             f"MCD12Q1.A2001001.h00v08.006.2018142182903_{subdataset_name}.tif"
-            for subdataset_name in subdataset_names
+            for subdataset_name in SUBDATASET_NAMES
         ]
         self.assertEqual(set(file_names), set(expected_cog_names))

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -17,7 +17,7 @@ SUBDATASET_NAMES = [
 
 class CogTest(TestCase):
 
-    def test_cog(self) -> None:
+    def test_add_cogs(self) -> None:
         infile = test_data.get_path(
             "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf")
         item = stactools.modis.stac.create_item(infile)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -20,7 +20,7 @@ class CreateItemTest(CliTestCase):
             "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml")
 
         with TemporaryDirectory() as temporary_directory:
-            cmd = f"modis create-item {infile} {temporary_directory}"
+            cmd = f"modis create-item --cogify {infile} {temporary_directory}"
             self.run_command(cmd)
             item_path = os.path.join(
                 temporary_directory,

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -30,3 +30,8 @@ def test_file() -> None:
         File("metadata.xml")
     with pytest.raises(ValueError):
         File("not-enough-dots.hdf.xml")
+
+    url = "http://example.com/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml"
+    file = File(url)
+    assert file.xml_path == url
+    assert file.hdf_path == "http://example.com/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf"


### PR DESCRIPTION
**Related Issue(s):**
- Closes #10 
- Closes #13 

**Description:**
- Fixes asset HREFs to be actual hrefs, not just the file name.
- Uses `make_all_asset_hrefs_relative()` in tests to keep absolute paths out of the expected JSON files
- Fixes cogification.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
