### PR TITLE
Metadata class

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,3 +10,9 @@ ignore_missing_imports = True
 
 [mypy-rasterio.*]
 ignore_missing_imports = True
+
+[mypy-fsspec.*]
+ignore_missing_imports = True
+
+[mypy-lxml.*]
+ignore_missing_imports = True

--- a/scripts/create_expected.py
+++ b/scripts/create_expected.py
@@ -21,7 +21,7 @@ for file_name in os.listdir(data_files_directory):
         collection.set_self_href(collection_path)
 
         item_file_name = f"{file.id}.json"
-        item = stactools.modis.stac.create_item(file.path)
+        item = stactools.modis.stac.create_item(file.href)
         item.validate()
 
         collection.add_item(item)

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -1,14 +1,12 @@
 import logging
 import os
-import warnings
 from typing import List, Optional, Tuple
 
-import rasterio
 import stactools.core.utils.convert
 from pystac import Asset, Item, MediaType
-from rasterio.errors import NotGeoreferencedWarning
 
 import stactools.modis.fragment
+import stactools.modis.utils
 from stactools.modis.constants import HDF_ASSET
 from stactools.modis.file import File
 
@@ -68,10 +66,7 @@ def cogify(infile: str, outdir: str) -> Tuple[List[str], List[str]]:
             - The first element is a list of the output tif paths
             - The second element is a list of subdataset names
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
-        with rasterio.open(infile) as dataset:
-            subdatasets = dataset.subdatasets
+    subdatasets = stactools.modis.utils.subdatasets(infile)
     base_file_name = os.path.splitext(os.path.basename(infile))[0]
     paths = []
     subdataset_names = []

--- a/src/stactools/modis/file.py
+++ b/src/stactools/modis/file.py
@@ -4,34 +4,34 @@ import os.path
 class File:
     """A MODIS file."""
 
-    path: str
-    hdf_path: str
-    xml_path: str
+    href: str
+    hdf_href: str
+    xml_href: str
     product: str
     version: str
     id: str
 
-    def __init__(self, path: str):
-        """Creates a new MODIS file from a path.
+    def __init__(self, href: str):
+        """Creates a new MODIS file from an href.
 
         Args:
-            path (str): The .hdf or .hdf.xml path to MODIS data
+            href (str): The .hdf or .hdf.xml href to MODIS data
         """
-        base, extension = os.path.splitext(path)
+        base, extension = os.path.splitext(href)
         if extension not in [".hdf", ".xml"]:
-            raise ValueError(f"Invalid MODIS path: {path}")
+            raise ValueError(f"Invalid MODIS href: {href}")
         elif extension == ".xml":
             if os.path.splitext(base)[1] != ".hdf":
                 raise ValueError(
-                    f"Invalid MODIS metadata path (no .hdf.xml): {path}")
+                    f"Invalid MODIS metadata href (no .hdf.xml): {href}")
             else:
-                self.xml_path = path
-                self.hdf_path = base
+                self.xml_href = href
+                self.hdf_href = base
         else:
-            self.xml_path = f"{path}.xml"
-            self.hdf_path = path
-        self.path = path
-        file_name = os.path.basename(self.hdf_path)
+            self.xml_href = f"{href}.xml"
+            self.hdf_href = href
+        self.href = href
+        file_name = os.path.basename(self.hdf_href)
         parts = file_name.split(".")
         if len(parts) < 4:
             raise ValueError(

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -1,0 +1,112 @@
+import datetime
+import os.path
+from typing import Callable, Optional
+
+import fsspec
+import shapely.geometry
+from lxml import etree
+from shapely.geometry import Polygon
+
+from stactools.core.io.xml import XmlElement
+
+
+class MissingElement(Exception):
+    """An expected element is missing from the XML file"""
+
+
+class Metadata:
+    """Structure to hold values fetched from a metadata XML file."""
+
+    def __init__(self, href: str):
+        """Reads fields from a metadata href."""
+
+        def missing_element(attribute: str) -> Callable[[str], Exception]:
+
+            def get_exception(xpath: str) -> Exception:
+                return MissingElement(
+                    f"Could not find attribute `{attribute}` at xpath '{xpath}' at href {href}"
+                )
+
+            return get_exception
+
+        with fsspec.open(href) as file:
+            root = XmlElement(etree.parse(file, base_url=href).getroot())
+
+        self.id = os.path.splitext(
+            root.find_text_or_throw(
+                "GranuleURMetaData/ECSDataGranule/LocalGranuleID",
+                missing_element("id")))[0]
+        self.product = root.find_text_or_throw(
+            "GranuleURMetaData/CollectionMetaData/ShortName",
+            missing_element("product"))
+        version = root.find_text_or_throw(
+            "GranuleURMetaData/CollectionMetaData/VersionID",
+            missing_element("version"))
+        if version == "6":
+            self.version = "006"
+        elif version == "61":
+            self.version = "061"
+        else:
+            raise ValueError(f"Unsupported MODIS version: {version}")
+
+        points = [(
+            float(
+                point.find_text_or_throw("PointLongitude",
+                                         missing_element("longitude"))),
+            float(
+                point.find_text_or_throw("PointLatitude",
+                                         missing_element("latitude")))
+        ) for point in root.findall(
+            "GranuleURMetaData/SpatialDomainContainer/HorizontalSpatialDomainContainer/"
+            "GPolygon/Boundary/Point")]
+        polygon = Polygon(points)
+        self.geometry = shapely.geometry.mapping(polygon)
+        self.bbox = polygon.bounds
+
+        start_date = root.find_text_or_throw(
+            "GranuleURMetaData/RangeDateTime/RangeBeginningDate",
+            missing_element("start_date"))
+        start_time = root.find_text_or_throw(
+            "GranuleURMetaData/RangeDateTime/RangeBeginningTime",
+            missing_element("start_time"))
+        self.start_datetime = datetime.datetime.fromisoformat(
+            f"{start_date}T{start_time}")
+        end_date = root.find_text_or_throw(
+            "GranuleURMetaData/RangeDateTime/RangeBeginningDate",
+            missing_element("end_date"))
+        end_time = root.find_text_or_throw(
+            "GranuleURMetaData/RangeDateTime/RangeEndingTime",
+            missing_element("end_time"))
+        self.end_datetime = datetime.datetime.fromisoformat(
+            f"{end_date}T{end_time}")
+
+        platforms = root.findall("GranuleURMetaData/Platform")
+        if len(platforms) == 1:
+            self.platform = platforms[0].find_text_or_throw(
+                "PlatformShortName",
+                missing_element("platform_short_name")).lower()
+        else:
+            # TODO what should we do about products that list both Terra and Aqua
+            # for their platforms?
+            self.platform = platforms[0].find_text_or_throw(
+                "PlatformShortName",
+                missing_element("platform_short_name")).lower()
+        self.instruments = list(
+            set(
+                platform.find_text_or_throw("Instrument/InstrumentShortName",
+                                            "instrument_short_name").lower()
+                for platform in platforms))
+
+    @property
+    def datetime(self) -> Optional[datetime.datetime]:
+        """Returns a single nominal datetime for this metadata file.
+
+        Depending on the product, this might be the midpoint between the
+        start and end datetimes, or it might be None.
+
+        Returns:
+            Optional[datetime.datetime]: The nominal datetime for this product.
+        """
+        # FIXME this is incorrect, need to account for the prouduct type
+        return self.start_datetime + (self.end_datetime -
+                                      self.start_datetime) / 2

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -89,16 +89,16 @@ class Metadata:
                                     missing_element("updated")))
 
         platforms = root.findall("GranuleURMetaData/Platform")
-        if len(platforms) == 1:
-            self.platform = platforms[0].find_text_or_throw(
+        # Per the discussion in
+        # https://github.com/radiantearth/stac-spec/issues/216, it seems like
+        # the recommendation for multi-platform datasets is to just include both
+        # and use a string seperator.
+        self.platform = ",".join([
+            platform.find_text_or_throw(
                 "PlatformShortName",
                 missing_element("platform_short_name")).lower()
-        else:
-            # TODO what should we do about products that list both Terra and Aqua
-            # for their platforms?
-            self.platform = platforms[0].find_text_or_throw(
-                "PlatformShortName",
-                missing_element("platform_short_name")).lower()
+            for platform in platforms
+        ])
         self.instruments = list(
             set(
                 platform.find_text_or_throw("Instrument/InstrumentShortName",

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -81,8 +81,8 @@ class Metadata:
             "RangeDateTime/RangeBeginningTime", missing_element("start_time"))
         self.start_datetime = datetime.datetime.fromisoformat(
             f"{start_date}T{start_time}")
-        end_date = metadata.find_text_or_throw(
-            "RangeDateTime/RangeBeginningDate", missing_element("end_date"))
+        end_date = metadata.find_text_or_throw("RangeDateTime/RangeEndingDate",
+                                               missing_element("end_date"))
         end_time = metadata.find_text_or_throw("RangeDateTime/RangeEndingTime",
                                                missing_element("end_time"))
         self.end_datetime = datetime.datetime.fromisoformat(

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -80,6 +80,14 @@ class Metadata:
         self.end_datetime = datetime.datetime.fromisoformat(
             f"{end_date}T{end_time}")
 
+        self.created = datetime.datetime.fromisoformat(
+            root.find_text_or_throw(
+                "GranuleURMetaData/ECSDataGranule/ProductionDateTime",
+                missing_element("created")))
+        self.updated = datetime.datetime.fromisoformat(
+            root.find_text_or_throw("GranuleURMetaData/LastUpdate",
+                                    missing_element("updated")))
+
         platforms = root.findall("GranuleURMetaData/Platform")
         if len(platforms) == 1:
             self.platform = platforms[0].find_text_or_throw(

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -6,9 +6,8 @@ import fsspec
 import shapely.geometry
 from lxml import etree
 from shapely.geometry import Polygon
-
-from stactools.core.io.xml import XmlElement
 from stactools.core.io import ReadHrefModifier
+from stactools.core.io.xml import XmlElement
 
 
 class MissingElement(Exception):
@@ -109,8 +108,9 @@ class Metadata:
         ])
         self.instruments = list(
             set(
-                platform.find_text_or_throw("Instrument/InstrumentShortName",
-                                            "instrument_short_name").lower()
+                platform.find_text_or_throw(
+                    "Instrument/InstrumentShortName",
+                    missing_element("instrument_short_name")).lower()
                 for platform in platforms))
 
     @property

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -65,16 +65,8 @@ def create_item(infile: str) -> Item:
         properties=stactools.modis.fragment.load_item_properties(
             metadata.product, metadata.version))
 
-    # Common metadata
-    # TODO should we remove these? They're in the collection
-    collection = stactools.modis.fragment.load_collection(
-        metadata.product, metadata.version)
-    item.common_metadata.providers = collection["providers"]
-    item.common_metadata.description = collection["description"]
-
     item.common_metadata.instruments = metadata.instruments
     item.common_metadata.platform = metadata.platform
-    item.common_metadata.title = collection["title"]
 
     # Hdf
     item.add_asset(

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 import pystac
 from pystac import Collection, Item, MediaType
 from pystac.extensions.eo import Band, EOExtension
 from pystac.extensions.item_assets import AssetDefinition, ItemAssetsExtension
+from stactools.core.io import ReadHrefModifier
 
 import stactools.modis.fragment
 from stactools.modis.constants import HDF_ASSET, METADATA_ASSET
@@ -46,17 +49,20 @@ def create_collection(product: str, version: str) -> Collection:
     return collection
 
 
-def create_item(infile: str) -> Item:
+def create_item(href: str,
+                read_href_modifier: Optional[ReadHrefModifier] = None) -> Item:
     """Creates a STAC Item from MODIS data.
 
     Args:
-        infile (str): The href to an HDF file or its metadata.
+        href (str): The href to an HDF file or its metadata.
+        read_href_modifier (Callable[[str], str]): An optional function to
+            modify the href (e.g. to add a token to a url)
 
     Returns:
         pystac.Item: A STAC Item representing this MODIS image.
     """
-    file = File(infile)
-    metadata = Metadata(file.xml_href)
+    file = File(href)
+    metadata = Metadata(file.xml_href, read_href_modifier)
     item = pystac.Item(
         id=metadata.id,
         geometry=metadata.geometry,

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -69,16 +69,12 @@ def create_item(infile: str) -> Item:
     item.common_metadata.platform = metadata.platform
     item.common_metadata.created = metadata.created
     item.common_metadata.updated = metadata.updated
-
-    # Hdf
     item.add_asset(
         HDF_ASSET,
         pystac.Asset(href=file.hdf_path,
                      media_type=MediaType.HDF,
                      roles=["data"],
                      title="hdf data"))
-
-    # Metadata
     item.add_asset(
         METADATA_ASSET,
         pystac.Asset(href=file.xml_path,
@@ -86,7 +82,6 @@ def create_item(infile: str) -> Item:
                      roles=["metadata"],
                      title="FGDC Metdata"))
 
-    # Bands
     eo = EOExtension.ext(item.assets[HDF_ASSET], add_if_missing=True)
     eo.bands = [
         Band(band) for band in stactools.modis.fragment.load_bands(

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -67,6 +67,8 @@ def create_item(infile: str) -> Item:
 
     item.common_metadata.instruments = metadata.instruments
     item.common_metadata.platform = metadata.platform
+    item.common_metadata.created = metadata.created
+    item.common_metadata.updated = metadata.updated
 
     # Hdf
     item.add_asset(

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -1,15 +1,12 @@
-import xml.etree.ElementTree as ET
-
 import pystac
 from pystac import Collection, Item, MediaType
 from pystac.extensions.eo import Band, EOExtension
 from pystac.extensions.item_assets import AssetDefinition, ItemAssetsExtension
-from pystac.utils import str_to_datetime
-from shapely.geometry import shape
 
 import stactools.modis.fragment
 from stactools.modis.constants import HDF_ASSET, METADATA_ASSET
 from stactools.modis.file import File
+from stactools.modis.metadata import Metadata
 
 
 def create_collection(product: str, version: str) -> Collection:
@@ -59,76 +56,24 @@ def create_item(infile: str) -> Item:
         pystac.Item: A STAC Item representing this MODIS image.
     """
     file = File(infile)
-    metadata_root = ET.parse(file.xml_path).getroot()
-
-    # Item id
-    product_element = metadata_root.find(
-        "GranuleURMetaData/CollectionMetaData/ShortName")
-    assert product_element is not None
-    product = product_element.text
-    version_element = metadata_root.find(
-        "GranuleURMetaData/CollectionMetaData/VersionID")
-    assert version_element is not None
-    version = version_element.text
-    if version == "6":
-        version = "006"
-    elif version == "61":
-        version = "061"
-    else:
-        raise ValueError(f"Unsupported MODIS version: {version}")
-
-    image_name = metadata_root.find(
-        "GranuleURMetaData/DataFiles/DataFileContainer/DistributedFileName")
-    assert image_name is not None
-    assert image_name.text is not None
-    id = image_name.text.replace(".hdf", "")
-
-    coordinates = []
-    point_ele = "{}/{}".format(
-        "GranuleURMetaData/SpatialDomainContainer/",
-        "HorizontalSpatialDomainContainer/GPolygon/Boundary/Point")
-    for point in metadata_root.findall(point_ele):
-        lon = point.find("PointLongitude")
-        assert lon is not None
-        assert lon.text is not None
-        lat = point.find("PointLatitude")
-        assert lat is not None
-        assert lat.text is not None
-        coordinates.append([float(lon.text), float(lat.text)])
-
-    geom = {"type": "Polygon", "coordinates": [coordinates]}
-
-    bounds = shape(geom).bounds
-
-    # Item date
-    prod_node = "GranuleURMetaData/ECSDataGranule/ProductionDateTime"
-    prod_dt_text = metadata_root.find(prod_node)
-    assert prod_dt_text is not None
-    assert prod_dt_text.text is not None
-    prod_dt = str_to_datetime(prod_dt_text.text)
-
+    metadata = Metadata(file.xml_path)
     item = pystac.Item(
-        id=id,
-        geometry=geom,
-        bbox=bounds,
-        datetime=prod_dt,
+        id=metadata.id,
+        geometry=metadata.geometry,
+        bbox=metadata.bbox,
+        datetime=metadata.datetime,
         properties=stactools.modis.fragment.load_item_properties(
-            product, version))
+            metadata.product, metadata.version))
 
     # Common metadata
-    collection = stactools.modis.fragment.load_collection(product, version)
+    # TODO should we remove these? They're in the collection
+    collection = stactools.modis.fragment.load_collection(
+        metadata.product, metadata.version)
     item.common_metadata.providers = collection["providers"]
     item.common_metadata.description = collection["description"]
 
-    instrument_short_name = metadata_root.find(
-        "GranuleURMetaData/Platform/Instrument/InstrumentShortName")
-    assert instrument_short_name is not None
-    assert instrument_short_name.text is not None
-    item.common_metadata.instruments = [instrument_short_name.text]
-    platform_short_name = metadata_root.find(
-        "GranuleURMetaData/Platform/PlatformShortName")
-    assert platform_short_name is not None
-    item.common_metadata.platform = platform_short_name.text
+    item.common_metadata.instruments = metadata.instruments
+    item.common_metadata.platform = metadata.platform
     item.common_metadata.title = collection["title"]
 
     # Hdf
@@ -150,8 +95,8 @@ def create_item(infile: str) -> Item:
     # Bands
     eo = EOExtension.ext(item.assets[HDF_ASSET], add_if_missing=True)
     eo.bands = [
-        Band(band)
-        for band in stactools.modis.fragment.load_bands(product, version)
+        Band(band) for band in stactools.modis.fragment.load_bands(
+            metadata.product, metadata.version)
     ]
 
     return item

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -13,6 +13,7 @@ from pystac.extensions.projection import ProjectionExtension
 from stactools.core.io import ReadHrefModifier
 
 import stactools.modis.fragment
+import stactools.modis.utils
 from stactools.modis.constants import HDF_ASSET, METADATA_ASSET
 from stactools.modis.file import File
 from stactools.modis.metadata import Metadata
@@ -102,8 +103,7 @@ def create_item(href: str,
 
     url = urllib.parse.urlparse(file.hdf_href)
     if not url.scheme and os.path.isfile(file.hdf_href):
-        with rasterio.open(file.hdf_href) as dataset:
-            subdatasets = dataset.subdatasets
+        subdatasets = stactools.modis.utils.subdatasets(file.hdf_href)
         if not subdatasets:
             raise ValueError(
                 f"No subdatasets found in HDF file: {file.hdf_href}")

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -80,6 +80,8 @@ def create_item(href: str,
 
     item.common_metadata.instruments = metadata.instruments
     item.common_metadata.platform = metadata.platform
+    item.common_metadata.start_datetime = metadata.start_datetime
+    item.common_metadata.end_datetime = metadata.end_datetime
     item.common_metadata.created = metadata.created
     item.common_metadata.updated = metadata.updated
     item.add_asset(

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -56,7 +56,7 @@ def create_item(infile: str) -> Item:
         pystac.Item: A STAC Item representing this MODIS image.
     """
     file = File(infile)
-    metadata = Metadata(file.xml_path)
+    metadata = Metadata(file.xml_href)
     item = pystac.Item(
         id=metadata.id,
         geometry=metadata.geometry,
@@ -71,13 +71,13 @@ def create_item(infile: str) -> Item:
     item.common_metadata.updated = metadata.updated
     item.add_asset(
         HDF_ASSET,
-        pystac.Asset(href=file.hdf_path,
+        pystac.Asset(href=file.hdf_href,
                      media_type=MediaType.HDF,
                      roles=["data"],
                      title="hdf data"))
     item.add_asset(
         METADATA_ASSET,
-        pystac.Asset(href=file.xml_path,
+        pystac.Asset(href=file.xml_href,
                      media_type=MediaType.XML,
                      roles=["metadata"],
                      title="FGDC Metdata"))

--- a/src/stactools/modis/utils.py
+++ b/src/stactools/modis/utils.py
@@ -1,0 +1,22 @@
+import warnings
+from typing import List, cast
+
+import rasterio
+from rasterio.errors import NotGeoreferencedWarning
+
+
+def subdatasets(href: str) -> List[str]:
+    """Returns a list of subdatasets from this HDF file href.
+
+    Includes a warning-cathcher so you don't get a "no CRS" warning while doing it.
+
+    Args:
+        href (str): The HREF to a MODIS HDF file.
+
+    Returns:
+        List[str]: A list of subdatasets (GDAL-openable paths)
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
+        with rasterio.open(href) as dataset:
+            return cast(List[str], dataset.subdatasets)

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -121,6 +121,8 @@
       "modis"
     ],
     "platform": "terra,aqua",
+    "start_datetime": "2001-01-01T00:00:00Z",
+    "end_datetime": "2001-01-01T23:59:59Z",
     "created": "2018-05-22T18:29:03Z",
     "updated": "2019-08-26T14:27:11.357000Z",
     "proj:epsg": null,

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -120,7 +120,7 @@
     "instruments": [
       "modis"
     ],
-    "platform": "terra",
+    "platform": "terra,aqua",
     "created": "2018-05-22T18:29:03Z",
     "updated": "2019-08-26T14:27:11.357000Z",
     "datetime": "2001-01-01T11:59:59.500000Z"

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -117,22 +117,10 @@
     "QC_Class_9": "Forest type changed: climate-based change to forest class.",
     "LW_Class_1": "1c0dff, Water",
     "LW_Class_2": "f9ffa4, Land",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MCD12Q1.006"
-      }
-    ],
-    "description": "The Terra and Aqua combined Moderate Resolution\nImaging Spectroradiometer (MODIS) Land Cover Type (MCD12Q1) Version 6 data product\nprovides global land cover types at yearly intervals (2001-2019), derived from six\ndifferent classification schemes listed in the User Guide. The MCD12Q1 Version 6\ndata product is derived using supervised classifications of MODIS Terra and Aqua\nreflectance data. The supervised classifications then undergo additional\npost-processing that incorporate prior knowledge and ancillary information to\nfurther refine specific classes.\n\nLayers for Land Cover Type 1-5, Land Cover Property 1-3, Land Cover Property\nAssessment 1-3, Land Cover Quality Control (QC), and a Land Water Mask are\nprovided in each MCD12Q1 Version 6 Hierarchical Data Format 4 (HDF4) file.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid",
     "datetime": "2001-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -122,7 +122,7 @@
     ],
     "platform": "terra,aqua",
     "start_datetime": "2001-01-01T00:00:00Z",
-    "end_datetime": "2001-01-01T23:59:59Z",
+    "end_datetime": "2001-12-31T23:59:59Z",
     "created": "2018-05-22T18:29:03Z",
     "updated": "2019-08-26T14:27:11.357000Z",
     "proj:epsg": null,
@@ -166,7 +166,7 @@
       2400,
       2400
     ],
-    "datetime": "2001-01-01T11:59:59.500000Z"
+    "datetime": "2001-07-02T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -123,6 +123,47 @@
     "platform": "terra,aqua",
     "created": "2018-05-22T18:29:03Z",
     "updated": "2019-08-26T14:27:11.357000Z",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -18903158.834333,
+            0.0
+          ],
+          [
+            -18903158.834333,
+            1111950.519667
+          ],
+          [
+            -20015109.354,
+            1111950.519667
+          ],
+          [
+            -20015109.354,
+            0.0
+          ],
+          [
+            -18903158.834333,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "proj:transform": [
+      463.3127165279165,
+      0.0,
+      -20015109.354,
+      0.0,
+      -463.3127165279167,
+      1111950.519667
+    ],
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "datetime": "2001-01-01T11:59:59.500000Z"
   },
   "geometry": {
@@ -251,7 +292,8 @@
     9.998978
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "collection": "modis-MCD12Q1-006"
 }

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -129,11 +129,11 @@
     ],
     "description": "The Terra and Aqua combined Moderate Resolution\nImaging Spectroradiometer (MODIS) Land Cover Type (MCD12Q1) Version 6 data product\nprovides global land cover types at yearly intervals (2001-2019), derived from six\ndifferent classification schemes listed in the User Guide. The MCD12Q1 Version 6\ndata product is derived using supervised classifications of MODIS Terra and Aqua\nreflectance data. The supervised classifications then undergo additional\npost-processing that incorporate prior knowledge and ancillary information to\nfurther refine specific classes.\n\nLayers for Land Cover Type 1-5, Land Cover Property 1-3, Land Cover Property\nAssessment 1-3, Land Cover Quality Control (QC), and a Land Water Mask are\nprovided in each MCD12Q1 Version 6 Hierarchical Data Format 4 (HDF4) file.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid",
-    "datetime": "2018-05-22T18:29:03Z"
+    "datetime": "2001-01-01T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -154,6 +154,10 @@
         [
           -169.991733,
           6e-06
+        ],
+        [
+          -179.999952,
+          -0.006836
         ]
       ]
     ]

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -121,6 +121,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2018-05-22T18:29:03Z",
+    "updated": "2019-08-26T14:27:11.357000Z",
     "datetime": "2001-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -6,7 +6,7 @@
     "instruments": [
       "modis"
     ],
-    "platform": "terra",
+    "platform": "terra,aqua",
     "created": "2022-01-28T11:20:24Z",
     "updated": "2022-01-28T05:33:06.715000Z",
     "datetime": "2022-01-11T12:00:00Z"

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -8,10 +8,10 @@
     ],
     "platform": "terra,aqua",
     "start_datetime": "2022-01-11T00:00:00Z",
-    "end_datetime": "2022-01-11T23:59:59.999999Z",
+    "end_datetime": "2022-01-26T23:59:59.999999Z",
     "created": "2022-01-28T11:20:24Z",
     "updated": "2022-01-28T05:33:06.715000Z",
-    "datetime": "2022-01-11T12:00:00Z"
+    "datetime": "2022-01-19T00:00:00Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -15,11 +15,11 @@
     ],
     "description": "\n            The Moderate Resolution Imaging Spectroradiometer (MODIS) MCD43A4\n             Version 6 Nadir Bidirectional Reflectance Distribution Function\n             (BRDF)-Adjusted Reflectance (NBAR) dataset is produced daily using\n             16 days of Terra and Aqua MODIS data at 500 meter (m) resolution.\n             The view angle effects are removed from the directional reflectances,\n             resulting in a stable and consistent NBAR product. Data are temporally\n             weighted to the ninth day which is reflected in the Julian date in the\n             file name.\n            ",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MCD43A4 v006 MODIS/Terra+Aqua Nadir BRDF-Adjusted Reflectance (NBAR) Daily L3 Global 500 m SIN Grid",
-    "datetime": "2022-01-28T11:20:24Z"
+    "datetime": "2022-01-11T12:00:00Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -40,6 +40,10 @@
         [
           -91.1909609510465,
           39.8554224326714
+        ],
+        [
+          -104.52019611598,
+          39.7556817203217
         ]
       ]
     ]

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -7,6 +7,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-28T11:20:24Z",
+    "updated": "2022-01-28T05:33:06.715000Z",
     "datetime": "2022-01-11T12:00:00Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -7,6 +7,8 @@
       "modis"
     ],
     "platform": "terra,aqua",
+    "start_datetime": "2022-01-11T00:00:00Z",
+    "end_datetime": "2022-01-11T23:59:59.999999Z",
     "created": "2022-01-28T11:20:24Z",
     "updated": "2022-01-28T05:33:06.715000Z",
     "datetime": "2022-01-11T12:00:00Z"

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -3,22 +3,10 @@
   "stac_version": "1.0.0",
   "id": "MCD43A4.A2022019.h10v04.006.2022028111747",
   "properties": {
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://lpdaac.usgs.gov/"
-      }
-    ],
-    "description": "\n            The Moderate Resolution Imaging Spectroradiometer (MODIS) MCD43A4\n             Version 6 Nadir Bidirectional Reflectance Distribution Function\n             (BRDF)-Adjusted Reflectance (NBAR) dataset is produced daily using\n             16 days of Terra and Aqua MODIS data at 500 meter (m) resolution.\n             The view angle effects are removed from the directional reflectances,\n             resulting in a stable and consistent NBAR product. Data are temporally\n             weighted to the ninth day which is reflected in the Julian date in the\n             file name.\n            ",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MCD43A4 v006 MODIS/Terra+Aqua Nadir BRDF-Adjusted Reflectance (NBAR) Daily L3 Global 500 m SIN Grid",
     "datetime": "2022-01-11T12:00:00Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -15,11 +15,11 @@
     ],
     "description": "\n            This data set contains daily, gridded snow cover and albedo derived from\n             radiance data acquired by the Moderate Resolution Imaging Spectroradiometer\n             (MODIS) on board the Terra satellite. Snow cover is identified using the\n             Normalized Difference Snow Index (NDSI) and a series of screens designed\n             to alleviate errors and flag uncertain snow cover detections.\n            ",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6",
-    "datetime": "2022-01-31T04:58:23Z"
+    "datetime": "2022-01-29T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -40,6 +40,10 @@
         [
           -80.5775666708921,
           29.8961896763571
+        ],
+        [
+          -92.3012472028587,
+          29.8410878424102
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -7,6 +7,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-31T04:58:23Z",
+    "updated": "2022-01-30T22:03:40.097000Z",
     "datetime": "2022-01-29T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -7,6 +7,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-29T00:00:00Z",
+    "end_datetime": "2022-01-29T23:59:59Z",
     "created": "2022-01-31T04:58:23Z",
     "updated": "2022-01-30T22:03:40.097000Z",
     "datetime": "2022-01-29T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -3,22 +3,10 @@
   "stac_version": "1.0.0",
   "id": "MOD10A1.A2022029.h10v05.006.2022031045818",
   "properties": {
-    "providers": [
-      {
-        "name": "NASA NSIDC DAAC at CIRES",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD10A1.006"
-      }
-    ],
-    "description": "\n            This data set contains daily, gridded snow cover and albedo derived from\n             radiance data acquired by the Moderate Resolution Imaging Spectroradiometer\n             (MODIS) on board the Terra satellite. Snow cover is identified using the\n             Normalized Difference Snow Index (NDSI) and a series of screens designed\n             to alleviate errors and flag uncertain snow cover detections.\n            ",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6",
     "datetime": "2022-01-29T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -31,11 +31,11 @@
     ],
     "description": "The MOD11A1 Version 6 product provides daily per-pixel Land Surface\n                         Temperature and Emissivity (LST&E) with 1 kilometer (km) spatial\n                         resolution in a 1,200 by 1,200 km grid. The pixel temperature value is\n                         derived from the MOD11_L2 swath product. Above 30 degrees latitude, some\n                         pixels may have multiple observations where the criteria for clear-sky\n                         are met. When this occurs, the pixel value is a result of the average\n                         of all qualifying observations. Provided along with the daytime and\n                         nighttime surface temperature bands are associated quality control\n                         assessments, observation times, view zenith angles, and clear-sky coverages\n                         along with bands 31 and 32 emissivities from land cover types.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid",
-    "datetime": "2022-01-31T09:48:27Z"
+    "datetime": "2022-01-30T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -56,6 +56,10 @@
         [
           -92.388605818441,
           30.0041666666667
+        ],
+        [
+          -104.438013067114,
+          39.9958333333333
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-30T00:00:00Z",
+    "end_datetime": "2022-01-30T23:59:59Z",
     "created": "2022-01-31T09:48:27Z",
     "updated": "2022-01-31T03:53:55.289000Z",
     "datetime": "2022-01-30T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -19,22 +19,10 @@
     "QC_LST_Error_flag_01": "average LST error <= 2K",
     "QC_LST_Error_flag_10": "average LST error <= 3K",
     "QC_LST_Error_flag_11": "average LST error > 3K",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD11A1.006"
-      }
-    ],
-    "description": "The MOD11A1 Version 6 product provides daily per-pixel Land Surface\n                         Temperature and Emissivity (LST&E) with 1 kilometer (km) spatial\n                         resolution in a 1,200 by 1,200 km grid. The pixel temperature value is\n                         derived from the MOD11_L2 swath product. Above 30 degrees latitude, some\n                         pixels may have multiple observations where the criteria for clear-sky\n                         are met. When this occurs, the pixel value is a result of the average\n                         of all qualifying observations. Provided along with the daytime and\n                         nighttime surface temperature bands are associated quality control\n                         assessments, observation times, view zenith angles, and clear-sky coverages\n                         along with bands 31 and 32 emissivities from land cover types.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid",
     "datetime": "2022-01-30T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-31T09:48:27Z",
+    "updated": "2022-01-31T03:53:55.289000Z",
     "datetime": "2022-01-30T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -24,10 +24,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-17T00:00:00Z",
-    "end_datetime": "2022-01-17T23:59:59Z",
+    "end_datetime": "2022-01-24T23:59:59Z",
     "created": "2022-01-26T20:57:24Z",
     "updated": "2022-01-26T23:32:16.338000Z",
-    "datetime": "2022-01-17T11:59:59.500000Z"
+    "datetime": "2022-01-20T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-26T20:57:24Z",
+    "updated": "2022-01-26T23:32:16.338000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -19,22 +19,10 @@
     "QC_LST_Error_flag_01": "average LST error <= 2K",
     "QC_LST_Error_flag_10": "average LST error <= 3K",
     "QC_LST_Error_flag_11": "average LST error > 3K",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD11A2.006"
-      }
-    ],
-    "description": "The MOD11A2 Version 6 product provides an average 8-day per-pixel\n                         Land Surface Temperature and Emissivity (LST&E) with a 1 kilometer (km)\n                         spatial resolution in a 1,200 by 1,200 km grid. Each pixel value in the\n                         MOD11A2 is a simple average of all the corresponding MOD11A1 LST pixels\n                         collected within that 8-day period. The 8-day compositing period was\n                         chosen because twice that period is the exact ground track repeat period\n                         of the Terra and Aqua platforms. Provided along with the daytime and\n                         nighttime surface temperature bands are associated quality control\n                         assessments, observation times, view zenith angles, and clear-sky\n                         coverages along with bands 31 and 32 emissivities from land\n                         cover types.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-17T00:00:00Z",
+    "end_datetime": "2022-01-17T23:59:59Z",
     "created": "2022-01-26T20:57:24Z",
     "updated": "2022-01-26T23:32:16.338000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -31,11 +31,11 @@
     ],
     "description": "The MOD11A2 Version 6 product provides an average 8-day per-pixel\n                         Land Surface Temperature and Emissivity (LST&E) with a 1 kilometer (km)\n                         spatial resolution in a 1,200 by 1,200 km grid. Each pixel value in the\n                         MOD11A2 is a simple average of all the corresponding MOD11A1 LST pixels\n                         collected within that 8-day period. The 8-day compositing period was\n                         chosen because twice that period is the exact ground track repeat period\n                         of the Terra and Aqua platforms. Provided along with the daytime and\n                         nighttime surface temperature bands are associated quality control\n                         assessments, observation times, view zenith angles, and clear-sky\n                         coverages along with bands 31 and 32 emissivities from land\n                         cover types.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid",
-    "datetime": "2022-01-26T20:57:24Z"
+    "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -56,6 +56,10 @@
         [
           -92.388605818441,
           30.0041666666667
+        ],
+        [
+          -104.438013067114,
+          39.9958333333333
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -44,22 +44,10 @@
     "Summary_QA_1": "Marginal data - Useful, but look at other QA information",
     "Summary_QA_2": "Snow/Ice - Target covered with snow/ice",
     "Summary_QA_3": "Cloudy - Target not visible, covered with cloud",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD13A1.006"
-      }
-    ],
-    "description": "The MOD13A1 Version 6 product provides Vegetation Index (VI) values at a per pixel basis\nat 500 meter (m) spatial resolution. There are two primary vegetation layers. The first\nis the Normalized Difference Vegetation Index (NDVI), which is referred to as the continuity\nindex to the existing National Oceanic and Atmospheric Administration-Advanced Very High\nResolution Radiometer (NOAA-AVHRR) derived NDVI. The second vegetation layer is the Enhanced\nVegetation Index (EVI), which has improved sensitivity over high biomass regions. The algorithm\nfor this product chooses the best available pixel value from all the acquisitions from the 16\nday period. The criteria used is low clouds, low view angle, and the highest NDVI/EVI value.\n\nProvided along with the vegetation layers and two quality assurance (QA) layers are reflectance\nbands 1 (red), 2 (near-infrared), 3 (blue), and 7 (mid-infrared), as well as four observation\nlayers.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid",
     "datetime": "2022-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -48,6 +48,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-01T00:00:00Z",
+    "end_datetime": "2022-01-01T23:59:59Z",
     "created": "2022-01-18T22:56:31Z",
     "updated": "2022-01-18T17:02:41.699000Z",
     "datetime": "2022-01-01T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -56,11 +56,11 @@
     ],
     "description": "The MOD13A1 Version 6 product provides Vegetation Index (VI) values at a per pixel basis\nat 500 meter (m) spatial resolution. There are two primary vegetation layers. The first\nis the Normalized Difference Vegetation Index (NDVI), which is referred to as the continuity\nindex to the existing National Oceanic and Atmospheric Administration-Advanced Very High\nResolution Radiometer (NOAA-AVHRR) derived NDVI. The second vegetation layer is the Enhanced\nVegetation Index (EVI), which has improved sensitivity over high biomass regions. The algorithm\nfor this product chooses the best available pixel value from all the acquisitions from the 16\nday period. The criteria used is low clouds, low view angle, and the highest NDVI/EVI value.\n\nProvided along with the vegetation layers and two quality assurance (QA) layers are reflectance\nbands 1 (red), 2 (near-infrared), 3 (blue), and 7 (mid-infrared), as well as four observation\nlayers.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid",
-    "datetime": "2022-01-18T22:56:31Z"
+    "datetime": "2022-01-01T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -81,6 +81,10 @@
         [
           -92.131858571552,
           29.9009502428382
+        ],
+        [
+          -103.835851753394,
+          29.8360532722546
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -49,10 +49,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-01T00:00:00Z",
-    "end_datetime": "2022-01-01T23:59:59Z",
+    "end_datetime": "2022-01-16T23:59:59Z",
     "created": "2022-01-18T22:56:31Z",
     "updated": "2022-01-18T17:02:41.699000Z",
-    "datetime": "2022-01-01T11:59:59.500000Z"
+    "datetime": "2022-01-08T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -48,6 +48,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-18T22:56:31Z",
+    "updated": "2022-01-18T17:02:41.699000Z",
     "datetime": "2022-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -48,6 +48,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-18T22:57:46Z",
+    "updated": "2022-01-18T17:05:27.039000Z",
     "datetime": "2022-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -49,10 +49,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-01T00:00:00Z",
-    "end_datetime": "2022-01-01T23:59:59Z",
+    "end_datetime": "2022-01-16T23:59:59Z",
     "created": "2022-01-18T22:57:46Z",
     "updated": "2022-01-18T17:05:27.039000Z",
-    "datetime": "2022-01-01T11:59:59.500000Z"
+    "datetime": "2022-01-08T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -44,22 +44,10 @@
     "Summary_QA_1": "Marginal data - Useful, but look at other QA information",
     "Summary_QA_2": "Snow/Ice - Target covered with snow/ice",
     "Summary_QA_3": "Cloudy - Target not visible, covered with cloud",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD13Q1.006"
-      }
-    ],
-    "description": "The Terra Moderate Resolution Imaging Spectroradiometer (MODIS) Vegetation Indices\n    (MOD13Q1) Version 6 data are generated every 16 days at 250 meter (m) spatial resolution\n    as a Level 3 product. The MOD13Q1 product provides two primary vegetation layers. The first\n    is the Normalized Difference Vegetation Index (NDVI) which is referred to as the continuity\n    index to the existing National Oceanic and Atmospheric Administration-Advanced Very High\n    Resolution Radiometer (NOAA-AVHRR) derived NDVI. The second vegetation layer is the Enhanced\n    Vegetation Index (EVI), which has improved sensitivity over high biomass regions. The algorithm\n    chooses the best available pixel value from all the acquisitions from the 16 day period. The\n    criteria used is low clouds, low view angle, and the highest NDVI/EVI value.\n\n    Along with the vegetation layers and the two quality layers, the HDF file will have MODIS\n    reflectance bands 1 (red), 2 (near-infrared), 3 (blue), and 7 (mid-infrared), as well as four\n    observation layers.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid",
     "datetime": "2022-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -48,6 +48,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-01T00:00:00Z",
+    "end_datetime": "2022-01-01T23:59:59Z",
     "created": "2022-01-18T22:57:46Z",
     "updated": "2022-01-18T17:05:27.039000Z",
     "datetime": "2022-01-01T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -56,11 +56,11 @@
     ],
     "description": "The Terra Moderate Resolution Imaging Spectroradiometer (MODIS) Vegetation Indices\n    (MOD13Q1) Version 6 data are generated every 16 days at 250 meter (m) spatial resolution\n    as a Level 3 product. The MOD13Q1 product provides two primary vegetation layers. The first\n    is the Normalized Difference Vegetation Index (NDVI) which is referred to as the continuity\n    index to the existing National Oceanic and Atmospheric Administration-Advanced Very High\n    Resolution Radiometer (NOAA-AVHRR) derived NDVI. The second vegetation layer is the Enhanced\n    Vegetation Index (EVI), which has improved sensitivity over high biomass regions. The algorithm\n    chooses the best available pixel value from all the acquisitions from the 16 day period. The\n    criteria used is low clouds, low view angle, and the highest NDVI/EVI value.\n\n    Along with the vegetation layers and the two quality layers, the HDF file will have MODIS\n    reflectance bands 1 (red), 2 (near-infrared), 3 (blue), and 7 (mid-infrared), as well as four\n    observation layers.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid",
-    "datetime": "2022-01-18T22:57:46Z"
+    "datetime": "2022-01-01T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -81,6 +81,10 @@
         [
           -92.131858571552,
           29.9009502428382
+        ],
+        [
+          -103.835851753394,
+          29.8360532722546
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -24,10 +24,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-17T00:00:00Z",
-    "end_datetime": "2022-01-17T23:59:59Z",
+    "end_datetime": "2022-01-24T23:59:59Z",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:06.516000Z",
-    "datetime": "2022-01-17T11:59:59.500000Z"
+    "datetime": "2022-01-20T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-26T20:56:45Z",
+    "updated": "2022-01-26T23:32:06.516000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -31,11 +31,11 @@
     ],
     "description": "The Terra Moderate Resolution Imaging\nSpectroradiometer (MODIS) Thermal Anomalies and Fire Daily\n(MOD14A1) Version 6 data are generated every eight days at 1 kilometer (km) spatial resolultion\nas a Level 3 product. MOD14A1 contains eight consecutive days of fire data conveniently packaged\ninto a single file.\n\nThe Science Dataset (SDS) layers include the fire mask, pixel quality indicators, maximum fire\nradiative power (MaxFRP), and the position of the fire pixel within the scan. Each layer consists of\ndaily per pixel information for each of the eight days of data acquisition.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid",
-    "datetime": "2022-01-26T20:56:45Z"
+    "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -56,6 +56,10 @@
         [
           -80.5775666708921,
           29.8961896763571
+        ],
+        [
+          -92.3012472028587,
+          29.8410878424102
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -19,22 +19,10 @@
     "QA_bit_0_1_land_water_state_3": "Missing data",
     "QA_bit_2_night_day_0": "Night",
     "QA_bit_2_night_day_1": "Day",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD44W.006"
-      }
-    ],
-    "description": "The Terra Moderate Resolution Imaging\nSpectroradiometer (MODIS) Thermal Anomalies and Fire Daily\n(MOD14A1) Version 6 data are generated every eight days at 1 kilometer (km) spatial resolultion\nas a Level 3 product. MOD14A1 contains eight consecutive days of fire data conveniently packaged\ninto a single file.\n\nThe Science Dataset (SDS) layers include the fire mask, pixel quality indicators, maximum fire\nradiative power (MaxFRP), and the position of the fire pixel within the scan. Each layer consists of\ndaily per pixel information for each of the eight days of data acquisition.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-17T00:00:00Z",
+    "end_datetime": "2022-01-17T23:59:59Z",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:06.516000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -31,11 +31,11 @@
     ],
     "description": "The Terra Moderate Resolution Imaging\nSpectroradiometer (MODIS) Thermal Anomalies and Fire 8-Day (MOD14A2)\nVersion 6 data are generated at 1 kilometer (km) spatial resolultion as\na Level 3 product. The MOD14A2 gridded composite contains the maximum value\nof the individual fire pixel classes detected during the eight days of acquisition.\n\nThe Science Dataset (SDS) layers include the fire mask and pixel quality indicators.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid",
-    "datetime": "2022-01-26T20:56:45Z"
+    "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -56,6 +56,10 @@
         [
           -80.5775666708921,
           29.8961896763571
+        ],
+        [
+          -92.3012472028587,
+          29.8410878424102
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -19,22 +19,10 @@
     "QA_bit_0_1_land_water_state_3": "Missing data",
     "QA_bit_2_night_day_0": "Night",
     "QA_bit_2_night_day_1": "Day",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD14A2.006"
-      }
-    ],
-    "description": "The Terra Moderate Resolution Imaging\nSpectroradiometer (MODIS) Thermal Anomalies and Fire 8-Day (MOD14A2)\nVersion 6 data are generated at 1 kilometer (km) spatial resolultion as\na Level 3 product. The MOD14A2 gridded composite contains the maximum value\nof the individual fire pixel classes detected during the eight days of acquisition.\n\nThe Science Dataset (SDS) layers include the fire mask and pixel quality indicators.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-17T00:00:00Z",
+    "end_datetime": "2022-01-17T23:59:59Z",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:05.772000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-26T20:56:45Z",
+    "updated": "2022-01-26T23:32:05.772000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -24,10 +24,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-17T00:00:00Z",
-    "end_datetime": "2022-01-17T23:59:59Z",
+    "end_datetime": "2022-01-24T23:59:59Z",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:05.772000Z",
-    "datetime": "2022-01-17T11:59:59.500000Z"
+    "datetime": "2022-01-20T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -30,11 +30,11 @@
     ],
     "description": "The MOD15A2H Version 6 Moderate Resolution Imaging Spectroradiometer (MODIS) combined Leaf Area\nIndex (LAI) and Fraction of Photosynthetically Active Radiation (FPAR) product is an 8-day\ncomposite dataset with 500 meter (m) pixel size. The algorithm chooses the \u201cbest\u201d pixel available\nfrom all the acquisitions of the Terra sensor from within the 8-day period.\n\nLAI is defined as the one-sided green leaf area per unit ground area in broadleaf canopies and\nas one-half the total needle surface area per unit ground area in coniferous canopies. FPAR is\ndefined as the fraction of incident photosynthetically active radiation, 400-700 nanometers (nm),\nabsorbed by the green elements of a vegetation canopy.\n\nScience Datasets (SDSs) in the Level 4 (L4) MOD15A2H product include LAI, FPAR, two quality layers,\nand standard deviation for LAI and FPAR. Two low resolution browse images, LAI and FPAR, are also\navailable for each MOD15A2H granule.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid",
-    "datetime": "2022-01-26T20:58:20Z"
+    "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -55,6 +55,10 @@
         [
           -80.5775666708921,
           29.8961896763571
+        ],
+        [
+          -92.3012472028587,
+          29.8410878424102
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -23,10 +23,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-17T00:00:00Z",
-    "end_datetime": "2022-01-17T23:59:59Z",
+    "end_datetime": "2022-01-24T23:59:59Z",
     "created": "2022-01-26T20:58:20Z",
     "updated": "2022-01-26T23:20:26.941000Z",
-    "datetime": "2022-01-17T11:59:59.500000Z"
+    "datetime": "2022-01-20T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -18,22 +18,10 @@
     "STD_LAI_STD_FPAR_fill_value_class_253": "Land cover assigned as barren, sparse vegetation (rock, tundra, desert)",
     "STD_LAI_STD_FPAR_fill_value_class_254": "Land cover assigned as perennial salt or inland fresh water",
     "STD_LAI_STD_FPAR_fill_value_class_255": "Fill",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD15A2H.006"
-      }
-    ],
-    "description": "The MOD15A2H Version 6 Moderate Resolution Imaging Spectroradiometer (MODIS) combined Leaf Area\nIndex (LAI) and Fraction of Photosynthetically Active Radiation (FPAR) product is an 8-day\ncomposite dataset with 500 meter (m) pixel size. The algorithm chooses the \u201cbest\u201d pixel available\nfrom all the acquisitions of the Terra sensor from within the 8-day period.\n\nLAI is defined as the one-sided green leaf area per unit ground area in broadleaf canopies and\nas one-half the total needle surface area per unit ground area in coniferous canopies. FPAR is\ndefined as the fraction of incident photosynthetically active radiation, 400-700 nanometers (nm),\nabsorbed by the green elements of a vegetation canopy.\n\nScience Datasets (SDSs) in the Level 4 (L4) MOD15A2H product include LAI, FPAR, two quality layers,\nand standard deviation for LAI and FPAR. Two low resolution browse images, LAI and FPAR, are also\navailable for each MOD15A2H granule.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -22,6 +22,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-17T00:00:00Z",
+    "end_datetime": "2022-01-17T23:59:59Z",
     "created": "2022-01-26T20:58:20Z",
     "updated": "2022-01-26T23:20:26.941000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -22,6 +22,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-26T20:58:20Z",
+    "updated": "2022-01-26T23:20:26.941000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -36,11 +36,11 @@
     ],
     "description": "The MOD16A3GF Version 6 Evapotranspiration/Latent Heat Flux (ET/LE) product is a year-end\ngap-filled yearly composite dataset produced at 500 meter (m) pixel resolution. The algorithm\nused for the MOD16 data product collection is based on the logic of the Penman-Monteith equation,\nwhich includes inputs of daily meteorological reanalysis data along with Moderate Resolution\nImaging Spectroradiometer (MODIS) remotely sensed data products such as vegetation property\ndynamics, albedo, and land cover.\n\nThe MOD16A3GF will be generated at the end of each year when the entire yearly 8-day MOD15A2H\nis available. Hence, the gap-filled MOD16A3GF is the improved MOD16, which has cleaned the\npoor-quality inputs from yearly Leaf Area Index and Fraction of Photosynthetically Active Radiation\n(LAI/FPAR) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR pixel did not\nmeet the quality screening criteria, its value is determined through linear interpolation. However,\nusers cannot get MOD16A3GF in near-real time because it will be generated only at the end of a given\nyear.\n\nProvided in the MOD16A3GF product are layers for composited ET, LE, Potential ET (PET), and\nPotential LE (PLE) along with a quality control layer. Two low resolution browse images, ET\nand LE, are also available for each MOD16A3GF granule.\n\nThe pixel values for the two Evapotranspiration layers (ET and PET) are the sum for all days\nwithin the defined year, and the pixel values for the two Latent Heat layers (LE and PLE) are\nthe average of all days within the defined year.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid",
-    "datetime": "2022-01-11T23:41:47Z"
+    "datetime": "2020-01-01T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -61,6 +61,10 @@
         [
           -104.235445821904,
           39.8623890159424
+        ],
+        [
+          -117.746445975456,
+          39.7342308150748
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -28,6 +28,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2020-01-01T00:00:00Z",
+    "end_datetime": "2020-01-01T23:59:59Z",
     "created": "2022-01-11T23:41:47Z",
     "updated": "2022-01-11T17:46:28.061000Z",
     "datetime": "2020-01-01T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -29,10 +29,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2020-01-01T00:00:00Z",
-    "end_datetime": "2020-01-01T23:59:59Z",
+    "end_datetime": "2020-12-31T23:59:59Z",
     "created": "2022-01-11T23:41:47Z",
     "updated": "2022-01-11T17:46:28.061000Z",
-    "datetime": "2020-01-01T11:59:59.500000Z"
+    "datetime": "2020-07-01T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -24,22 +24,10 @@
     "ET_QC_500m_fill_value_class_32765": "Land cover assigned as barren, sparse vegetation (rock, tundra, desert)",
     "ET_QC_500m_fill_value_class_32766": "Land cover assigned as perennial salt or water bodies",
     "ET_QC_500m_fill_value_class_32767": "Fill",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD16A3GF.006"
-      }
-    ],
-    "description": "The MOD16A3GF Version 6 Evapotranspiration/Latent Heat Flux (ET/LE) product is a year-end\ngap-filled yearly composite dataset produced at 500 meter (m) pixel resolution. The algorithm\nused for the MOD16 data product collection is based on the logic of the Penman-Monteith equation,\nwhich includes inputs of daily meteorological reanalysis data along with Moderate Resolution\nImaging Spectroradiometer (MODIS) remotely sensed data products such as vegetation property\ndynamics, albedo, and land cover.\n\nThe MOD16A3GF will be generated at the end of each year when the entire yearly 8-day MOD15A2H\nis available. Hence, the gap-filled MOD16A3GF is the improved MOD16, which has cleaned the\npoor-quality inputs from yearly Leaf Area Index and Fraction of Photosynthetically Active Radiation\n(LAI/FPAR) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR pixel did not\nmeet the quality screening criteria, its value is determined through linear interpolation. However,\nusers cannot get MOD16A3GF in near-real time because it will be generated only at the end of a given\nyear.\n\nProvided in the MOD16A3GF product are layers for composited ET, LE, Potential ET (PET), and\nPotential LE (PLE) along with a quality control layer. Two low resolution browse images, ET\nand LE, are also available for each MOD16A3GF granule.\n\nThe pixel values for the two Evapotranspiration layers (ET and PET) are the sum for all days\nwithin the defined year, and the pixel values for the two Latent Heat layers (LE and PLE) are\nthe average of all days within the defined year.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid",
     "datetime": "2020-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -28,6 +28,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-11T23:41:47Z",
+    "updated": "2022-01-11T17:46:28.061000Z",
     "datetime": "2020-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -29,6 +29,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-26T22:24:24Z",
+    "updated": "2022-01-27T01:09:02.847000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -30,10 +30,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2022-01-17T00:00:00Z",
-    "end_datetime": "2022-01-17T23:59:59Z",
+    "end_datetime": "2022-01-24T23:59:59Z",
     "created": "2022-01-26T22:24:24Z",
     "updated": "2022-01-27T01:09:02.847000Z",
-    "datetime": "2022-01-17T11:59:59.500000Z"
+    "datetime": "2022-01-20T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -37,11 +37,11 @@
     ],
     "description": "The MOD17A2H Version 6 Gross Primary Productivity (GPP)\nproduct is a cumulative 8-day composite of\nvalues with 500 meter (m) pixel size based on the radiation use efficiency concept that can be\npotentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle\nprocesses, and biogeochemistry of vegetation. The data product includes information about GPP\nand Net Photosynthesis (PSN). The PSN band values are the GPP less the Maintenance Respiration\n(MR). The data product also contains a PSN Quality Control (QC) layer. The quality layer\ncontains quality information for both the GPP and thePSN.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN",
-    "datetime": "2022-01-26T22:24:24Z"
+    "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -62,6 +62,10 @@
         [
           -104.235445821904,
           39.8623890159424
+        ],
+        [
+          -117.746445975456,
+          39.7342308150748
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -29,6 +29,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2022-01-17T00:00:00Z",
+    "end_datetime": "2022-01-17T23:59:59Z",
     "created": "2022-01-26T22:24:24Z",
     "updated": "2022-01-27T01:09:02.847000Z",
     "datetime": "2022-01-17T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -25,22 +25,10 @@
     "SCF_QC_010": "2, Main (RT) method failed due to bad geometry, empirical algorithm used",
     "SCF_QC_011": "3, Main (RT) method failed due to problems other than geometry,empirical algorithm used",
     "SCF_QC_100": "4, Pixel not produced at all, value coudn't be retrieved(possible reasons: bad L1B data, unusable MOD09GA data)",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD17A2H.006"
-      }
-    ],
-    "description": "The MOD17A2H Version 6 Gross Primary Productivity (GPP)\nproduct is a cumulative 8-day composite of\nvalues with 500 meter (m) pixel size based on the radiation use efficiency concept that can be\npotentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle\nprocesses, and biogeochemistry of vegetation. The data product includes information about GPP\nand Net Photosynthesis (PSN). The PSN band values are the GPP less the Maintenance Respiration\n(MR). The data product also contains a PSN Quality Control (QC) layer. The quality layer\ncontains quality information for both the GPP and thePSN.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN",
     "datetime": "2022-01-17T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -25,22 +25,10 @@
     "SCF_QC_010": "2, Main (RT) method failed due to bad geometry, empirical algorithm used",
     "SCF_QC_011": "3, Main (RT) method failed due to problems other than geometry, empirical algorithm used",
     "SCF_QC_100": "4, Pixel not produced at all, value coudn't be retrieved (possible reasons: badL1B data, unusable MOD09GA data)",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD17A2HGF.006"
-      }
-    ],
-    "description": "The MOD17A2HGF Version 6 Gross Primary Productivity (GPP) product\nis a cumulative 8-day composite of\nvalues with 500 meter (m) pixel size based on the radiation use efficiency concept that can\nbe potentially used as inputs to data models to calculate terrestrial energy, carbon, water\ncycle processes, and biogeochemistry of vegetation. The data product includes information\nabout GPP and Net Photosynthesis (PSN). The PSN band values are the GPP less the Maintenance\nRespiration (MR). The data product also contains a PSN Quality Control (QC) layer. The quality\nlayer contains quality information for both the GPP and the PSN.\n\nThe MOD17A2HGF will be generated at the end of each year when the entire yearly 8-day MOD15A2H\nis available. Hence, the gap-filled MOD17A2HGF is the improved MOD17, which has cleaned the\npoor-quality inputs from 8-day Leaf Area Index and Fraction of Photosynthetically Active\nRadiation (FPAR/LAI) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR\npixel did not meet the quality screening criteria, its value is determined through linear\ninterpolation. However, users cannot get MOD17A2HGF in near-real time because it will be\ngenerated only at the end of a given year.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid",
     "datetime": "2021-12-03T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -29,6 +29,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2021-12-03T00:00:00Z",
+    "end_datetime": "2021-12-03T23:59:59Z",
     "created": "2022-01-31T14:10:00Z",
     "updated": "2022-01-31T08:16:07.542000Z",
     "datetime": "2021-12-03T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -29,6 +29,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2022-01-31T14:10:00Z",
+    "updated": "2022-01-31T08:16:07.542000Z",
     "datetime": "2021-12-03T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -37,11 +37,11 @@
     ],
     "description": "The MOD17A2HGF Version 6 Gross Primary Productivity (GPP) product\nis a cumulative 8-day composite of\nvalues with 500 meter (m) pixel size based on the radiation use efficiency concept that can\nbe potentially used as inputs to data models to calculate terrestrial energy, carbon, water\ncycle processes, and biogeochemistry of vegetation. The data product includes information\nabout GPP and Net Photosynthesis (PSN). The PSN band values are the GPP less the Maintenance\nRespiration (MR). The data product also contains a PSN Quality Control (QC) layer. The quality\nlayer contains quality information for both the GPP and the PSN.\n\nThe MOD17A2HGF will be generated at the end of each year when the entire yearly 8-day MOD15A2H\nis available. Hence, the gap-filled MOD17A2HGF is the improved MOD17, which has cleaned the\npoor-quality inputs from 8-day Leaf Area Index and Fraction of Photosynthetically Active\nRadiation (FPAR/LAI) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR\npixel did not meet the quality screening criteria, its value is determined through linear\ninterpolation. However, users cannot get MOD17A2HGF in near-real time because it will be\ngenerated only at the end of a given year.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid",
-    "datetime": "2022-01-31T14:10:00Z"
+    "datetime": "2021-12-03T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -62,6 +62,10 @@
         [
           -92.131858571552,
           29.9009502428382
+        ],
+        [
+          -103.835851753394,
+          29.8360532722546
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -30,10 +30,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2021-12-03T00:00:00Z",
-    "end_datetime": "2021-12-03T23:59:59Z",
+    "end_datetime": "2021-12-10T23:59:59Z",
     "created": "2022-01-31T14:10:00Z",
     "updated": "2022-01-31T08:16:07.542000Z",
-    "datetime": "2021-12-03T11:59:59.500000Z"
+    "datetime": "2021-12-06T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -29,11 +29,11 @@
     ],
     "description": "The MOD17A3HGF Version 6 product provides information\nabout annual Net Primary Production (NPP) at 500 meter (m) pixel resolution.\nAnnual NPP is derived from the sum of all 8-day Net Photosynthesis (PSN) products\n(MOD17A2H) from the given year. The PSN value is the difference of the Gross\nPrimary Productivity (GPP) and the Maintenance Respiration (MR).\n\nThe MOD17A3HGF will be generated at the end of each year when the entire yearly\n8-day MOD15A2H is available. Hence, the gap-filled MOD17A3HGF is the improved MOD17,\nwhich has cleaned the poor-quality inputs from 8-day Leaf Area Index and Fraction\nof Photosynthetically Active Radiation (LAI/FPAR) based on the Quality Control (QC)\nlabel for every pixel. If any LAI/FPAR pixel did not meet the quality screening\ncriteria, its value is determined through linear interpolation. However, users\ncannot get MOD17A3HGF in near-real time because it will be generated only at the\nend of a given year.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid",
-    "datetime": "2021-04-23T15:01:37Z"
+    "datetime": "2020-01-01T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -54,6 +54,10 @@
         [
           -104.235445821904,
           39.8623890159424
+        ],
+        [
+          -117.746445975456,
+          39.7342308150748
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -21,6 +21,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2021-04-23T15:01:37Z",
+    "updated": "2021-04-23T10:04:29.686000Z",
     "datetime": "2020-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -17,22 +17,10 @@
     "Npp_500m_fill_value_class_253": "Land cover assigned as barren, sparse vegetation (rock, tundra, desert)",
     "Npp_500m_fill_value_class_254": "Land cover assigned as perennial salt or water bodies",
     "Npp_500m_fill_value_class_255": "Fill",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD17A2HGF.006"
-      }
-    ],
-    "description": "The MOD17A3HGF Version 6 product provides information\nabout annual Net Primary Production (NPP) at 500 meter (m) pixel resolution.\nAnnual NPP is derived from the sum of all 8-day Net Photosynthesis (PSN) products\n(MOD17A2H) from the given year. The PSN value is the difference of the Gross\nPrimary Productivity (GPP) and the Maintenance Respiration (MR).\n\nThe MOD17A3HGF will be generated at the end of each year when the entire yearly\n8-day MOD15A2H is available. Hence, the gap-filled MOD17A3HGF is the improved MOD17,\nwhich has cleaned the poor-quality inputs from 8-day Leaf Area Index and Fraction\nof Photosynthetically Active Radiation (LAI/FPAR) based on the Quality Control (QC)\nlabel for every pixel. If any LAI/FPAR pixel did not meet the quality screening\ncriteria, its value is determined through linear interpolation. However, users\ncannot get MOD17A3HGF in near-real time because it will be generated only at the\nend of a given year.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid",
     "datetime": "2020-01-01T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -21,6 +21,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2020-01-01T00:00:00Z",
+    "end_datetime": "2020-01-01T23:59:59Z",
     "created": "2021-04-23T15:01:37Z",
     "updated": "2021-04-23T10:04:29.686000Z",
     "datetime": "2020-01-01T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -22,10 +22,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2020-01-01T00:00:00Z",
-    "end_datetime": "2020-01-01T23:59:59Z",
+    "end_datetime": "2020-12-31T23:59:59Z",
     "created": "2021-04-23T15:01:37Z",
     "updated": "2021-04-23T10:04:29.686000Z",
-    "datetime": "2020-01-01T11:59:59.500000Z"
+    "datetime": "2020-07-01T23:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -40,10 +40,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2005-12-27T00:00:00Z",
-    "end_datetime": "2005-12-27T23:59:59Z",
+    "end_datetime": "2005-12-31T23:59:59Z",
     "created": "2018-10-13T18:15:06Z",
     "updated": "2018-10-14T20:17:00.495000Z",
-    "datetime": "2005-12-27T11:59:59.500000Z"
+    "datetime": "2005-12-29T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -47,11 +47,11 @@
     ],
     "description": "A new suite of Moderate Resolution Imaging Spectroradiometer (MODIS)\n            Land Surface Temperature and Emissivity (LST&E) products are available in\n            Collection 6. The MOD21 Land Surface Temperatuer (LST) algorithm differs from\n            the algorithm of the MOD11 LST products, in that the MOD21 algorithm is based\n            on the ASTER Temperature/Emissivity Separation (TES) technique, whereas the\n            MOD11 uses the split-window technique. The MOD21 TES algorithm uses a\n            physics-based algorithm to dynamically retrieve both the LST and spectral\n            emissivity simultaneously from the MODIS thermal infrared bands 29, 31, and 32.\n            The TES algorithm is combined with an improved Water Vapor Scaling (WVS)\n            atmospheric correction scheme to stabilize the retrieval during very warm and\n            humid conditions.\n\n            The MOD21A2 dataset is an 8-day composite LST product that uses an algorithm\n            based on a simple averaging method. The algorithm calculates the average from\n            all the cloud free MOD21A1D and MOD21A1N daily acquisitions from the 8-day period.\n            Unlike the MOD21A1 data sets where the daytime and nighttime acquisitions are\n            separate products, the MOD21A2 contains both daytime and nighttime acquisitions as\n            separate Science Dataset (SDS) layers within a single Hierarchical Data Format (HDF)\n            file. The LST, Quality Control (QC), view zenith angle, and viewing time have separate\n            day and night SDS layers, while the values for the MODIS emissivity bands 29, 31, and\n            32 are the average of both the nighttime and daytime acquisitions. MOD21A2 products\n            are available two months after acquisition due to latency of data inputs. Additional\n            details regarding the method used to create this Level 3 (L3) product are available\n            in the Algorithm Theoretical Basis Document (ATBD).",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid",
-    "datetime": "2018-10-13T18:15:06Z"
+    "datetime": "2005-12-27T11:59:59.500000Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -72,6 +72,10 @@
         [
           -91.1909609510465,
           39.8554224326714
+        ],
+        [
+          -104.52019611598,
+          39.7556817203217
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -39,6 +39,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2018-10-13T18:15:06Z",
+    "updated": "2018-10-14T20:17:00.495000Z",
     "datetime": "2005-12-27T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -35,22 +35,10 @@
     "QC_LST_accuracy_01": "1.5 - 2 K (Marginal performance)",
     "QC_LST_accuracy_10": "1 - 1.5 K (Good performance)",
     "QC_LST_accuracy_11": "<1 K (Excellent performance)",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD21A2.006"
-      }
-    ],
-    "description": "A new suite of Moderate Resolution Imaging Spectroradiometer (MODIS)\n            Land Surface Temperature and Emissivity (LST&E) products are available in\n            Collection 6. The MOD21 Land Surface Temperatuer (LST) algorithm differs from\n            the algorithm of the MOD11 LST products, in that the MOD21 algorithm is based\n            on the ASTER Temperature/Emissivity Separation (TES) technique, whereas the\n            MOD11 uses the split-window technique. The MOD21 TES algorithm uses a\n            physics-based algorithm to dynamically retrieve both the LST and spectral\n            emissivity simultaneously from the MODIS thermal infrared bands 29, 31, and 32.\n            The TES algorithm is combined with an improved Water Vapor Scaling (WVS)\n            atmospheric correction scheme to stabilize the retrieval during very warm and\n            humid conditions.\n\n            The MOD21A2 dataset is an 8-day composite LST product that uses an algorithm\n            based on a simple averaging method. The algorithm calculates the average from\n            all the cloud free MOD21A1D and MOD21A1N daily acquisitions from the 8-day period.\n            Unlike the MOD21A1 data sets where the daytime and nighttime acquisitions are\n            separate products, the MOD21A2 contains both daytime and nighttime acquisitions as\n            separate Science Dataset (SDS) layers within a single Hierarchical Data Format (HDF)\n            file. The LST, Quality Control (QC), view zenith angle, and viewing time have separate\n            day and night SDS layers, while the values for the MODIS emissivity bands 29, 31, and\n            32 are the average of both the nighttime and daytime acquisitions. MOD21A2 products\n            are available two months after acquisition due to latency of data inputs. Additional\n            details regarding the method used to create this Level 3 (L3) product are available\n            in the Algorithm Theoretical Basis Document (ATBD).",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid",
     "datetime": "2005-12-27T11:59:59.500000Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -39,6 +39,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2005-12-27T00:00:00Z",
+    "end_datetime": "2005-12-27T23:59:59Z",
     "created": "2018-10-13T18:15:06Z",
     "updated": "2018-10-14T20:17:00.495000Z",
     "datetime": "2005-12-27T11:59:59.500000Z"

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2020-03-05T00:00:00Z",
+    "end_datetime": "2020-03-05T00:00:00Z",
     "created": "2021-06-04T15:56:36Z",
     "updated": "2021-06-04T11:50:13.011000Z",
     "datetime": "2020-03-05T00:00:00Z"

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -31,11 +31,11 @@
     ],
     "description": "The MOD44B Version 6 Vegetation Continuous Fields\n(VCF) yearly product is a global representation of surface vegetation cover as\ngradations of three ground cover components: percent tree cover, percent non-tree\ncover, and percent non-vegetated (bare). VCF products provide a continuous,\nquantitative portrayal of land surface cover at 250 meter (m) pixel resolution,\nwith a sub-pixel depiction of percent cover in reference to the three ground cover\ncomponents. The sub-pixel mixture of ground cover estimates represents a revolutionary\napproach to the characterization of vegetative land cover that can be used to enhance\ninputs to environmental modeling and monitoring applications.\n\nThe MOD44B data product layers include percent tree cover, percent non-tree cover,\npercent non-vegetated, cloud cover, and quality indicators. The start date of the\nannual period for this product begins with day of year (DOY) 65 (March 5).",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid",
-    "datetime": "2021-06-04T15:56:36Z"
+    "datetime": "2020-03-05T00:00:00Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -56,6 +56,10 @@
         [
           -104.235445821904,
           39.8623890159424
+        ],
+        [
+          -117.746445975456,
+          39.7342308150748
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -24,10 +24,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2020-03-05T00:00:00Z",
-    "end_datetime": "2020-03-05T00:00:00Z",
+    "end_datetime": "2021-03-06T00:00:00Z",
     "created": "2021-06-04T15:56:36Z",
     "updated": "2021-06-04T11:50:13.011000Z",
-    "datetime": "2020-03-05T00:00:00Z"
+    "datetime": "2020-09-04T00:00:00Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -19,22 +19,10 @@
     "Quality_5_DOY_305_to_337": "0 Clear; 1 Bad",
     "Quality_6_DOY_353_to_017": "0 Clear; 1 Bad",
     "Quality_7_DOY_033_to_045": "0 Clear; 1 Bad",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD44B.006"
-      }
-    ],
-    "description": "The MOD44B Version 6 Vegetation Continuous Fields\n(VCF) yearly product is a global representation of surface vegetation cover as\ngradations of three ground cover components: percent tree cover, percent non-tree\ncover, and percent non-vegetated (bare). VCF products provide a continuous,\nquantitative portrayal of land surface cover at 250 meter (m) pixel resolution,\nwith a sub-pixel depiction of percent cover in reference to the three ground cover\ncomponents. The sub-pixel mixture of ground cover estimates represents a revolutionary\napproach to the characterization of vegetative land cover that can be used to enhance\ninputs to environmental modeling and monitoring applications.\n\nThe MOD44B data product layers include percent tree cover, percent non-tree cover,\npercent non-vegetated, cloud cover, and quality indicators. The start date of the\nannual period for this product begins with day of year (DOY) 65 (March 5).",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid",
     "datetime": "2020-03-05T00:00:00Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -23,6 +23,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2021-06-04T15:56:36Z",
+    "updated": "2021-06-04T11:50:13.011000Z",
     "datetime": "2020-03-05T00:00:00Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -15,22 +15,10 @@
     "QA_7": "Urban or impervious surface",
     "QA_8": "No water detected, but MOD44W V5 shows inland water",
     "QA_10": "Fill - outside of projected area",
-    "providers": [
-      {
-        "name": "NASA LP DAAC at the USGS EROS Center",
-        "roles": [
-          "producer",
-          "licensor"
-        ],
-        "url": "https://doi.org/10.5067/MODIS/MOD44W.006"
-      }
-    ],
-    "description": "The Terra Moderate Resolution Imaging Spectroradiometer\n(MODIS) Land Water Mask (MOD44W) Version 6 data product provides a global\nmap of surface water at 250 meter (m) spatial resolution. The data are\navailable annually from 2000 to 2015. MOD44W Version 6 is derived using a\ndecision tree classifier trained with MODIS data and validated with the\nVersion 5 MOD44W data product. A series of masks are applied to address\nknown issues caused by terrain shadow, burn scars, cloudiness, or ice cover\nin oceans. A primary improvement in Version 6 is the generation of time series\ndata rather than a simple static representation of water, given that water bodies\nfluctuate in size and location over time due to both natural and anthropogenic causes.\nProvided in each MOD44W Version 6 Hierarchical Data Format 4 (HDF4) file are layers\nfor land, water, no data, and an associated per pixel quality assurance (QA) layer\nthat provides users with information on the determination of water.",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
-    "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid",
     "datetime": "2015-01-01T00:00:00Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -20,10 +20,10 @@
     ],
     "platform": "terra",
     "start_datetime": "2015-01-01T00:00:00Z",
-    "end_datetime": "2015-01-01T00:00:00Z",
+    "end_datetime": "2015-12-31T00:00:00Z",
     "created": "2018-02-02T15:02:44Z",
     "updated": "2018-04-04T12:07:35.020000Z",
-    "datetime": "2015-01-01T00:00:00Z"
+    "datetime": "2015-07-02T00:00:00Z"
   },
   "geometry": {
     "type": "Polygon",

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -27,11 +27,11 @@
     ],
     "description": "The Terra Moderate Resolution Imaging Spectroradiometer\n(MODIS) Land Water Mask (MOD44W) Version 6 data product provides a global\nmap of surface water at 250 meter (m) spatial resolution. The data are\navailable annually from 2000 to 2015. MOD44W Version 6 is derived using a\ndecision tree classifier trained with MODIS data and validated with the\nVersion 5 MOD44W data product. A series of masks are applied to address\nknown issues caused by terrain shadow, burn scars, cloudiness, or ice cover\nin oceans. A primary improvement in Version 6 is the generation of time series\ndata rather than a simple static representation of water, given that water bodies\nfluctuate in size and location over time due to both natural and anthropogenic causes.\nProvided in each MOD44W Version 6 Hierarchical Data Format 4 (HDF4) file are layers\nfor land, water, no data, and an associated per pixel quality assurance (QA) layer\nthat provides users with information on the determination of water.",
     "instruments": [
-      "MODIS"
+      "modis"
     ],
-    "platform": "Terra",
+    "platform": "terra",
     "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid",
-    "datetime": "2018-02-02T15:02:44Z"
+    "datetime": "2015-01-01T00:00:00Z"
   },
   "geometry": {
     "type": "Polygon",
@@ -52,6 +52,10 @@
         [
           -91.190961,
           39.855422
+        ],
+        [
+          -104.520196,
+          39.755682
         ]
       ]
     ]

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -19,6 +19,8 @@
       "modis"
     ],
     "platform": "terra",
+    "created": "2018-02-02T15:02:44Z",
+    "updated": "2018-04-04T12:07:35.020000Z",
     "datetime": "2015-01-01T00:00:00Z"
   },
   "geometry": {

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -19,6 +19,8 @@
       "modis"
     ],
     "platform": "terra",
+    "start_datetime": "2015-01-01T00:00:00Z",
+    "end_datetime": "2015-01-01T00:00:00Z",
     "created": "2018-02-02T15:02:44Z",
     "updated": "2018-04-04T12:07:35.020000Z",
     "datetime": "2015-01-01T00:00:00Z"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -6,23 +6,23 @@ from . import test_data
 
 
 def test_file() -> None:
-    path = test_data.get_path(
+    href = test_data.get_path(
         "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml")
-    file = File(path)
-    assert file.path == path
-    assert file.hdf_path == test_data.get_path(
+    file = File(href)
+    assert file.href == href
+    assert file.hdf_href == test_data.get_path(
         "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf")
-    assert file.xml_path == path
+    assert file.xml_href == href
     assert file.version == "006"
     assert file.product == "MCD12Q1"
     assert file.id == "MCD12Q1.A2001001.h00v08.006.2018142182903"
 
-    path = test_data.get_path(
+    href = test_data.get_path(
         "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf")
-    file = File(path)
-    assert file.xml_path == test_data.get_path(
+    file = File(href)
+    assert file.xml_href == test_data.get_path(
         "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml")
-    assert file.hdf_path == path
+    assert file.hdf_href == href
 
     with pytest.raises(ValueError):
         File("not cool")
@@ -33,5 +33,5 @@ def test_file() -> None:
 
     url = "http://example.com/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml"
     file = File(url)
-    assert file.xml_path == url
-    assert file.hdf_path == "http://example.com/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf"
+    assert file.xml_href == url
+    assert file.hdf_href == "http://example.com/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf"

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -23,7 +23,7 @@ for file_name in os.listdir(directory):
                                    file.version, "collection.json")
     item_path = os.path.join(directory, "expected", file.product, file.version,
                              file.id, f"{file.id}.json")
-    args.append((file.path, collection_path, item_path))
+    args.append((file.href, collection_path, item_path))
     ids.append(file.product)
 
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -76,3 +76,18 @@ def test_metadata_files(metadata_path: str, collection_path: str,
 def test_collection_id() -> None:
     assert stactools.modis.stac.collection_id(
         "product", "version") == "modis-product-version"
+
+
+def test_read_href_modifier() -> None:
+    href = test_data.get_path(
+        "data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml")
+
+    did_it = False
+
+    def read_href_modifier(href: str) -> str:
+        nonlocal did_it
+        did_it = True
+        return href
+
+    _ = stactools.modis.stac.create_item(href, read_href_modifier)
+    assert did_it

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -52,12 +52,15 @@ def test_metadata_files(metadata_path: str, collection_path: str,
     with TemporaryDirectory() as temporary_directory:
         temporary_metadata_path = os.path.join(temporary_directory,
                                                os.path.basename(metadata_path))
+        temporary_file = File(temporary_metadata_path)
         expected_directory = os.path.join(temporary_directory, "expected",
                                           modis_file.product,
                                           modis_file.version)
         collection.set_self_href(
             os.path.join(expected_directory, "collection.json"))
-        shutil.copyfile(metadata_path, temporary_metadata_path)
+        shutil.copyfile(modis_file.xml_href, temporary_file.xml_href)
+        if os.path.exists(modis_file.hdf_href):
+            shutil.copyfile(modis_file.hdf_href, temporary_file.hdf_href)
         item = stactools.modis.stac.create_item(temporary_metadata_path)
         collection.add_item(item)
         collection.make_all_asset_hrefs_relative()


### PR DESCRIPTION
**Related Issue(s):**
- Closes #15 

**Description:** Creates a `Metadata` class to hold all of the XML parsing. Makes some corrections to STAC items, e.g. fixing the geometry, all of the datetimes, platforms, and instruments. Adds the proj extension if there is a _local_ HDF file available.

TODO: Fix the datetimes (#22) to be more intelligent about what product the Item is being created for. Might involve some sort of lookup function that takes the product, the start time, and the end time, and does The Right Thing™.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.

