### PR TITLE
Add scientific extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [proj](https://github.com/stac-extensions/projection)
   - [eo](https://github.com/stac-extensions/eo)
   - [item-assets](https://github.com/stac-extensions/item-assets)
+  - [scientific](https://github.com/stac-extensions/scientific)
 - Extra Fields: TODO
 
 This repository will assist you in the generation of STAC files for MODIS datasets. 

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -12,15 +12,15 @@
     },
     {
       "rel": "child",
-      "href": "./modis-061/catalog.json",
-      "type": "application/json",
-      "title": "MODIS, version 061"
-    },
-    {
-      "rel": "child",
       "href": "./modis-006/catalog.json",
       "type": "application/json",
       "title": "MODIS, version 006"
+    },
+    {
+      "rel": "child",
+      "href": "./modis-061/catalog.json",
+      "type": "application/json",
+      "title": "MODIS, version 061"
     }
   ],
   "stac_extensions": [],

--- a/examples/modis-006/modis-MCD12Q1-006/collection.json
+++ b/examples/modis-006/modis-MCD12Q1-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MCD12Q1.006"
+    },
+    {
       "rel": "item",
       "href": "./MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -105,6 +110,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MCD12Q1.006",
   "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD10A1-006/collection.json
+++ b/examples/modis-006/modis-MOD10A1-006/collection.json
@@ -16,6 +16,10 @@
       "title": "Hall, D. K., V. V. Salomonson, and G. A. Riggs. 2016. MODIS/Terra Snow Cover Daily L3 Global 500m Grid. Version 6. Boulder, Colorado USA: NASA National Snow and Ice Data Center Distributed Active Archive Center."
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD10A1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json",
       "type": "application/json"
@@ -28,7 +32,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -76,6 +81,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD10A1.006",
   "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD11A1-006/collection.json
+++ b/examples/modis-006/modis-MOD11A1-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD11A1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -101,6 +106,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD11A1.006",
   "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD11A2-006/collection.json
+++ b/examples/modis-006/modis-MOD11A2-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD11A2.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -101,6 +106,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD11A2.006",
   "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD13A1-006/collection.json
+++ b/examples/modis-006/modis-MOD13A1-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD13A1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -105,6 +110,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD13A1.006",
   "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD13Q1-006/collection.json
+++ b/examples/modis-006/modis-MOD13Q1-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD13Q1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -105,6 +110,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD13Q1.006",
   "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD14A1-006/collection.json
+++ b/examples/modis-006/modis-MOD14A1-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD44W.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -69,6 +74,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD44W.006",
   "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD14A2-006/collection.json
+++ b/examples/modis-006/modis-MOD14A2-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD14A2.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -61,6 +66,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD14A2.006",
   "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD15A2H-006/collection.json
+++ b/examples/modis-006/modis-MOD15A2H-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD15A2H.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -77,6 +82,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD15A2H.006",
   "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD16A3GF-006/collection.json
+++ b/examples/modis-006/modis-MOD16A3GF-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD16A3GF.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -73,6 +78,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD16A3GF.006",
   "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD17A2H-006/collection.json
+++ b/examples/modis-006/modis-MOD17A2H-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2H.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -65,6 +70,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2H.006",
   "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD17A2HGF-006/collection.json
+++ b/examples/modis-006/modis-MOD17A2HGF-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2HGF.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -65,6 +70,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2HGF.006",
   "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD17A3HGF-006/collection.json
+++ b/examples/modis-006/modis-MOD17A3HGF-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2HGF.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -61,6 +66,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2HGF.006",
   "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD21A2-006/collection.json
+++ b/examples/modis-006/modis-MOD21A2-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD21A2.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -97,6 +102,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD21A2.006",
   "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD44B-006/collection.json
+++ b/examples/modis-006/modis-MOD44B-006/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD44B.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -81,6 +86,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD44B.006",
   "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-006/modis-MOD44W-006/collection.json
+++ b/examples/modis-006/modis-MOD44W-006/collection.json
@@ -16,6 +16,10 @@
       "title": "User Guide"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD44W.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json",
       "type": "application/json"
@@ -28,7 +32,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -56,6 +61,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD44W.006",
   "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid",
   "extent": {
     "spatial": {

--- a/examples/modis-061/modis-MOD17A2HGF-061/collection.json
+++ b/examples/modis-061/modis-MOD17A2HGF-061/collection.json
@@ -21,6 +21,10 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2HGF.061"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A2HGF.A2021361.h10v06.061.2022020134637/MOD17A2HGF.A2021361.h10v06.061.2022020134637.json",
       "type": "application/json"
@@ -33,7 +37,8 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -65,6 +70,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2HGF.061",
   "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MCD12Q1/006/collection.json
+++ b/tests/data-files/expected/MCD12Q1/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MCD12Q1.006"
+    },
+    {
       "rel": "item",
       "href": "./MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -99,6 +104,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MCD12Q1.006",
   "title": "MODIS/Terra+Aqua Land Cover Type Yearly L3 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD10A1/006/collection.json
+++ b/tests/data-files/expected/MOD10A1/006/collection.json
@@ -16,13 +16,18 @@
       "title": "Hall, D. K., V. V. Salomonson, and G. A. Riggs. 2016. MODIS/Terra Snow Cover Daily L3 Global 500m Grid. Version 6. Boulder, Colorado USA: NASA National Snow and Ice Data Center Distributed Active Archive Center."
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD10A1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -70,6 +75,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD10A1.006",
   "title": "MODIS/Terra Snow Cover Daily L3 Global 500m SIN Grid, Version 6",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD11A1/006/collection.json
+++ b/tests/data-files/expected/MOD11A1/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD11A1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -95,6 +100,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD11A1.006",
   "title": "MODIS/Terra Land Surface Temperature/Emissivity Daily L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD11A2/006/collection.json
+++ b/tests/data-files/expected/MOD11A2/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD11A2.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -95,6 +100,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD11A2.006",
   "title": "MODIS/Terra Land Surface Temperature/Emissivity 8-Day L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD13A1/006/collection.json
+++ b/tests/data-files/expected/MOD13A1/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD13A1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -99,6 +104,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD13A1.006",
   "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD13Q1/006/collection.json
+++ b/tests/data-files/expected/MOD13Q1/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD13Q1.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -99,6 +104,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD13Q1.006",
   "title": "MODIS/Terra Vegetation Indices 16-Day L3 Global 250 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD14A1/006/collection.json
+++ b/tests/data-files/expected/MOD14A1/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD44W.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -63,6 +68,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD44W.006",
   "title": "MODIS/Terra Thermal Anomalies/Fire Daily L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD14A2/006/collection.json
+++ b/tests/data-files/expected/MOD14A2/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD14A2.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -55,6 +60,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD14A2.006",
   "title": "MODIS/Terra Thermal Anomalies/Fire 8-Day L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD15A2H/006/collection.json
+++ b/tests/data-files/expected/MOD15A2H/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD15A2H.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -71,6 +76,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD15A2H.006",
   "title": "MODIS/Terra Leaf Area Index/FPAR 8-Day L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD16A3GF/006/collection.json
+++ b/tests/data-files/expected/MOD16A3GF/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD16A3GF.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -67,6 +72,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD16A3GF.006",
   "title": "MODIS/Terra Net Evapotranspiration Gap-Filled Yearly L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD17A2H/006/collection.json
+++ b/tests/data-files/expected/MOD17A2H/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2H.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -59,6 +64,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2H.006",
   "title": "MODIS/Terra Gross Primary Productivity 8-Day L4 Global 500 m SIN",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD17A2HGF/006/collection.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2HGF.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -59,6 +64,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2HGF.006",
   "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD17A2HGF/061/collection.json
+++ b/tests/data-files/expected/MOD17A2HGF/061/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2HGF.061"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A2HGF.A2021361.h10v06.061.2022020134637/MOD17A2HGF.A2021361.h10v06.061.2022020134637.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -59,6 +64,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2HGF.061",
   "title": "MODIS/Terra Gross Primary Productivity Gap-Filled 8-Day L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD17A3HGF/006/collection.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD17A2HGF.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -55,6 +60,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD17A2HGF.006",
   "title": "MODIS/Terra Net Primary Production Gap-Filled Yearly L4 Global 500 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD21A2/006/collection.json
+++ b/tests/data-files/expected/MOD21A2/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD21A2.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -91,6 +96,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD21A2.006",
   "title": "MODIS/Terra Land Surface Temperature/3-Band Emissivity 8-Day L3 Global 1 km SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD44B/006/collection.json
+++ b/tests/data-files/expected/MOD44B/006/collection.json
@@ -21,13 +21,18 @@
       "title": "Data File"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD44B.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -75,6 +80,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD44B.006",
   "title": "MODIS/Terra Vegetation Continuous Fields Yearly L3 Global 250 m SIN Grid",
   "extent": {
     "spatial": {

--- a/tests/data-files/expected/MOD44W/006/collection.json
+++ b/tests/data-files/expected/MOD44W/006/collection.json
@@ -16,13 +16,18 @@
       "title": "User Guide"
     },
     {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.5067/MODIS/MOD44W.006"
+    },
+    {
       "rel": "item",
       "href": "./MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json",
       "type": "application/json"
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "item_assets": {
     "hdf": {
@@ -50,6 +55,7 @@
       "title": "FGDC Metdata"
     }
   },
+  "sci:doi": "10.5067/MODIS/MOD44W.006",
   "title": "MODIS/Terra Land Water Mask Derived from MODIS and SRTM L3 Yearly Global 250 m SIN Grid",
   "extent": {
     "spatial": {


### PR DESCRIPTION
**Related Issue(s):** Closes #31.

**Description:** Adds the scientific extension. Finds the doi in the collections fragment in the providers section. It's a little implicit, but works easily with the existing fragments w/o making changes.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.

