### PR TITLE
Use stactools v0.2.6 or newer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages =
     stactools.modis
     stactools.modis.fragments
 install_requires =
-    stactools @ git+https://github.com/stac-utils/stactools@7a3a08f46ba07607f26dd36e60630d75dc9759d0
+    stactools >= 0.2.6
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** Now that stactools doesn't have a GDAL Python dependency, we should be safe to use a versioned dependency.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).



