### PR TITLE
COG filename fixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Formatting in V006 fragments ([#45](https://github.com/stactools-packages/modis/pull/45))
-- Extents for V061 collections ([#53](https://github.com/stactools-packages/modis/pull/52))
+- Extents for V061 collections ([#52](https://github.com/stactools-packages/modis/pull/52))
+- Spaces are disallowed in COG filenames ([#53](https://github.com/stactools-packages/modis/pull/53))
 
 ## [0.1.0] - 2022-02-17
 

--- a/examples/modis-006/modis-MOD14A1-006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/examples/modis-006/modis-MOD14A1-006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -98,7 +98,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ],

--- a/examples/modis-006/modis-MOD14A1-006/collection.json
+++ b/examples/modis-006/modis-MOD14A1-006/collection.json
@@ -61,7 +61,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ]

--- a/examples/modis-061/modis-MOD14A1-061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
+++ b/examples/modis-061/modis-MOD14A1-061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
@@ -83,7 +83,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ],

--- a/examples/modis-061/modis-MOD14A1-061/collection.json
+++ b/examples/modis-061/modis-MOD14A1-061/collection.json
@@ -61,7 +61,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ]

--- a/examples/modis-061/modis-MYD14A1-061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
+++ b/examples/modis-061/modis-MYD14A1-061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
@@ -83,7 +83,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ],

--- a/examples/modis-061/modis-MYD14A1-061/collection.json
+++ b/examples/modis-061/modis-MYD14A1-061/collection.json
@@ -61,7 +61,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ]

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -133,8 +133,9 @@ def cogify(infile: str, outdir: str) -> Tuple[List[str], List[str]]:
     for subdataset in subdatasets:
         parts = subdataset.split(":")
         subdataset_name = parts[-1]
-        subdataset_names.append(subdataset_name)
-        file_name = f"{base_file_name}_{subdataset_name}.tif"
+        sanitized_subdataset_name = subdataset_name.replace(" ", "_")
+        subdataset_names.append(sanitized_subdataset_name)
+        file_name = f"{base_file_name}_{sanitized_subdataset_name}.tif"
         outfile = os.path.join(outdir, file_name)
         stactools.core.utils.convert.cogify(subdataset, outfile)
         paths.append(outfile)

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def add_cogs(item: Item,
              directory: str,
-             create: Optional[bool] = False) -> Tuple[List[str], List[str]]:
+             create: bool = False) -> Tuple[List[str], List[str]]:
     """Add the COGs in the directory to the provided item.
 
     Args:

--- a/src/stactools/modis/fragments/MOD14A1/006/bands.json
+++ b/src/stactools/modis/fragments/MOD14A1/006/bands.json
@@ -12,7 +12,7 @@
         "description": "Maximum Fire Radiative Power"
     },
     {
-        "name": "Sample",
+        "name": "sample",
         "description": "Position of fire pixel within scan"
     }
 ]

--- a/src/stactools/modis/fragments/MOD14A1/061/bands.json
+++ b/src/stactools/modis/fragments/MOD14A1/061/bands.json
@@ -12,7 +12,7 @@
         "description": "Maximum Fire Radiative Power"
     },
     {
-        "name": "Sample",
+        "name": "sample",
         "description": "Position of fire pixel within scan"
     }
 ]

--- a/src/stactools/modis/fragments/MOD14A1/061/raster-bands.json
+++ b/src/stactools/modis/fragments/MOD14A1/061/raster-bands.json
@@ -14,7 +14,7 @@
         "unit": "Megawatts",
         "scale": 0.1
     },
-    "Sample": {
+    "sample": {
         "data_type": "uint16",
         "unit": "Number",
         "scale": null

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -88,7 +88,7 @@ def create_collection(product: str, version: str) -> Collection:
 
 def create_item(href: str,
                 cog_directory: Optional[str] = None,
-                create_cogs: Optional[bool] = None,
+                create_cogs: bool = False,
                 read_href_modifier: Optional[ReadHrefModifier] = None) -> Item:
     """Creates a STAC Item from MODIS data.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,75 @@
 from stactools.testing.test_data import TestData
 
-test_data = TestData(__file__)
+test_data = TestData(
+    __file__, {
+        "MOD13A1.A2022033.h09v05.061.2022051005006.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MOD13A1.A2022033.h09v05.061.2022051005006.hdf"
+        },
+        "MOD13A1.A2022033.h09v05.061.2022051005006.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MOD13A1.A2022033.h09v05.061.2022051005006.hdf.xml"
+        },
+        "MOD13Q1.A2022033.h09v05.061.2022051005101.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MOD13Q1.A2022033.h09v05.061.2022051005101.hdf"
+        },
+        "MOD13Q1.A2022033.h09v05.061.2022051005101.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MOD13Q1.A2022033.h09v05.061.2022051005101.hdf.xml"
+        },
+        "MOD14A1.A2022049.h09v05.061.2022057235503.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MOD14A1.A2022049.h09v05.061.2022057235503.hdf"
+        },
+        "MOD14A1.A2022049.h09v05.061.2022057235503.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MOD14A1.A2022049.h09v05.061.2022057235503.hdf.xml"
+        },
+        "MYD10A1.A2022059.h09v05.061.2022061043435.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD10A1.A2022059.h09v05.061.2022061043435.hdf"
+        },
+        "MYD10A1.A2022059.h09v05.061.2022061043435.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD10A1.A2022059.h09v05.061.2022061043435.hdf.xml"
+        },
+        "MYD13A1.A2022041.h09v05.061.2022059190534.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD13A1.A2022041.h09v05.061.2022059190534.hdf"
+        },
+        "MYD13A1.A2022041.h09v05.061.2022059190534.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD13A1.A2022041.h09v05.061.2022059190534.hdf.xml"
+        },
+        "MYD13Q1.A2022041.h09v05.061.2022059190716.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD13Q1.A2022041.h09v05.061.2022059190716.hdf"
+        },
+        "MYD13Q1.A2022041.h09v05.061.2022059190716.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD13Q1.A2022041.h09v05.061.2022059190716.hdf.xml"
+        },
+        "MYD14A1.A2022049.h09v05.061.2022057234556.hdf": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD14A1.A2022049.h09v05.061.2022057234556.hdf"
+        },
+        "MYD14A1.A2022049.h09v05.061.2022057234556.hdf.xml": {
+            "url":
+            "https://ai4epublictestdata.blob.core.windows.net/stactools/modis"
+            "/MYD14A1.A2022049.h09v05.061.2022057234556.hdf.xml"
+        },
+    })

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -98,7 +98,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ],

--- a/tests/data-files/expected/MOD14A1/006/collection.json
+++ b/tests/data-files/expected/MOD14A1/006/collection.json
@@ -55,7 +55,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ]

--- a/tests/data-files/expected/MOD14A1/061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
+++ b/tests/data-files/expected/MOD14A1/061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
@@ -83,7 +83,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ],

--- a/tests/data-files/expected/MOD14A1/061/collection.json
+++ b/tests/data-files/expected/MOD14A1/061/collection.json
@@ -55,7 +55,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ]

--- a/tests/data-files/expected/MYD14A1/061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
+++ b/tests/data-files/expected/MYD14A1/061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
@@ -83,7 +83,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ],

--- a/tests/data-files/expected/MYD14A1/061/collection.json
+++ b/tests/data-files/expected/MYD14A1/061/collection.json
@@ -55,7 +55,7 @@
           "description": "Maximum Fire Radiative Power"
         },
         {
-          "name": "Sample",
+          "name": "sample",
           "description": "Position of fire pixel within scan"
         }
       ]

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -10,6 +10,15 @@ import stactools.modis.stac
 from tests import test_data
 
 SUBDATASET_NAMES = ["Eight_Day_Snow_Cover", "Maximum_Snow_Extent"]
+FAILING_COG_FILE_NAMES = [
+    "MOD14A1.A2022049.h09v05.061.2022057235503.hdf",
+    "MOD13Q1.A2022033.h09v05.061.2022051005101.hdf",
+    "MOD14A1.A2022049.h09v05.061.2022057235503.hdf",
+    "MYD10A1.A2022059.h09v05.061.2022061043435.hdf",
+    "MYD13A1.A2022041.h09v05.061.2022059190534.hdf",
+    "MYD13Q1.A2022041.h09v05.061.2022059190716.hdf",
+    "MYD14A1.A2022049.h09v05.061.2022057234556.hdf",
+]
 
 
 class CogTest(TestCase):
@@ -49,3 +58,18 @@ class CogTest(TestCase):
             for subdataset_name in SUBDATASET_NAMES
         ]
         self.assertEqual(set(file_names), set(expected_cog_names))
+
+
+@pytest.mark.parametrize("file_name", FAILING_COG_FILE_NAMES)
+@pytest.mark.skip(reason="these are very long and were used for a one-time fix"
+                  )
+def test_failing_cogs(file_name: str) -> None:
+    """These tests are from an initial attempt at cogifying all 36 modis V061
+    products in late February 2022.
+    """
+    infile = test_data.get_external_data(file_name)
+    _ = test_data.get_external_data(f"{file_name}.xml")
+    item = stactools.modis.stac.create_item(infile)
+    with TemporaryDirectory() as temporary_directory:
+        _, _ = stactools.modis.cog.cogify(infile, temporary_directory)
+        stactools.modis.cog.add_cogs(item, temporary_directory, create=False)


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** Removes spaces from subdataset names used to create COGs, and changes the capitalization of one band. Includes sidecar fixes to function arguments.

The unit tests to check that these work are skipped, because they're long and the external data they use are heavy. They can always be re-enabled as needed.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Example STAC Catalog has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
