### PR TITLE
Use keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Return paths and subdatasest names from `stactools.modis.cogs.add_cogs` ([#44](https://github.com/stactools-packages/modis/pull/44))
 - Keywords and summaries to collections ([#48](https://github.com/stactools-packages/modis/pull/48))
 - More Item and Collection metadata ([#51](https://github.com/stactools-packages/modis/pull/51))
+- Keywords for Collections ([#54](https://github.com/stactools-packages/modis/pull/54))
 
 ### Changed
 
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Formatting in V006 fragments ([#45](https://github.com/stactools-packages/modis/pull/45))
 - Extents for V061 collections ([#52](https://github.com/stactools-packages/modis/pull/52))
 - Spaces are disallowed in COG filenames ([#53](https://github.com/stactools-packages/modis/pull/53))
+- Use keywords when creating Collections ([#56](https://github.com/stactools-packages/modis/pull/56))
 
 ## [0.1.0] - 2022-02-17
 

--- a/examples/modis-006/modis-MCD12Q1-006/collection.json
+++ b/examples/modis-006/modis-MCD12Q1-006/collection.json
@@ -133,9 +133,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MCD43A4-006/collection.json
+++ b/examples/modis-006/modis-MCD43A4-006/collection.json
@@ -144,9 +144,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD10A1-006/collection.json
+++ b/examples/modis-006/modis-MOD10A1-006/collection.json
@@ -104,9 +104,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA NSIDC DAAC at CIRES",

--- a/examples/modis-006/modis-MOD11A1-006/collection.json
+++ b/examples/modis-006/modis-MOD11A1-006/collection.json
@@ -129,9 +129,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD11A2-006/collection.json
+++ b/examples/modis-006/modis-MOD11A2-006/collection.json
@@ -129,9 +129,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD13A1-006/collection.json
+++ b/examples/modis-006/modis-MOD13A1-006/collection.json
@@ -133,9 +133,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD13Q1-006/collection.json
+++ b/examples/modis-006/modis-MOD13Q1-006/collection.json
@@ -133,9 +133,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD14A1-006/collection.json
+++ b/examples/modis-006/modis-MOD14A1-006/collection.json
@@ -97,9 +97,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD14A2-006/collection.json
+++ b/examples/modis-006/modis-MOD14A2-006/collection.json
@@ -89,9 +89,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD15A2H-006/collection.json
+++ b/examples/modis-006/modis-MOD15A2H-006/collection.json
@@ -105,9 +105,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD16A3GF-006/collection.json
+++ b/examples/modis-006/modis-MOD16A3GF-006/collection.json
@@ -101,9 +101,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD17A2H-006/collection.json
+++ b/examples/modis-006/modis-MOD17A2H-006/collection.json
@@ -93,9 +93,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD17A2HGF-006/collection.json
+++ b/examples/modis-006/modis-MOD17A2HGF-006/collection.json
@@ -93,9 +93,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD17A3HGF-006/collection.json
+++ b/examples/modis-006/modis-MOD17A3HGF-006/collection.json
@@ -89,9 +89,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD21A2-006/collection.json
+++ b/examples/modis-006/modis-MOD21A2-006/collection.json
@@ -125,9 +125,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD44B-006/collection.json
+++ b/examples/modis-006/modis-MOD44B-006/collection.json
@@ -109,9 +109,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-006/modis-MOD44W-006/collection.json
+++ b/examples/modis-006/modis-MOD44W-006/collection.json
@@ -84,9 +84,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/examples/modis-061/modis-MCD15A2H-061/collection.json
+++ b/examples/modis-061/modis-MCD15A2H-061/collection.json
@@ -106,7 +106,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MCD15A3H-061/collection.json
+++ b/examples/modis-061/modis-MCD15A3H-061/collection.json
@@ -106,7 +106,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MCD43A4-061/collection.json
+++ b/examples/modis-061/modis-MCD43A4-061/collection.json
@@ -138,7 +138,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MCD64A1-061/collection.json
+++ b/examples/modis-061/modis-MCD64A1-061/collection.json
@@ -102,7 +102,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD09A1-061/collection.json
+++ b/examples/modis-061/modis-MOD09A1-061/collection.json
@@ -134,7 +134,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD09Q1-061/collection.json
+++ b/examples/modis-061/modis-MOD09Q1-061/collection.json
@@ -98,7 +98,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD10A1-061/collection.json
+++ b/examples/modis-061/modis-MOD10A1-061/collection.json
@@ -105,7 +105,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD10A2-061/collection.json
+++ b/examples/modis-061/modis-MOD10A2-061/collection.json
@@ -85,7 +85,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD11A1-061/collection.json
+++ b/examples/modis-061/modis-MOD11A1-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD11A2-061/collection.json
+++ b/examples/modis-061/modis-MOD11A2-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD13A1-061/collection.json
+++ b/examples/modis-061/modis-MOD13A1-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD13Q1-061/collection.json
+++ b/examples/modis-061/modis-MOD13Q1-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD14A1-061/collection.json
+++ b/examples/modis-061/modis-MOD14A1-061/collection.json
@@ -98,7 +98,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD14A2-061/collection.json
+++ b/examples/modis-061/modis-MOD14A2-061/collection.json
@@ -90,7 +90,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD15A2H-061/collection.json
+++ b/examples/modis-061/modis-MOD15A2H-061/collection.json
@@ -106,7 +106,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD16A3GF-061/collection.json
+++ b/examples/modis-061/modis-MOD16A3GF-061/collection.json
@@ -102,7 +102,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Water"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD17A2H-061/collection.json
+++ b/examples/modis-061/modis-MOD17A2H-061/collection.json
@@ -94,7 +94,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD17A2HGF-061/collection.json
+++ b/examples/modis-061/modis-MOD17A2HGF-061/collection.json
@@ -94,7 +94,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD17A3HGF-061/collection.json
+++ b/examples/modis-061/modis-MOD17A3HGF-061/collection.json
@@ -94,7 +94,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MOD21A2-061/collection.json
+++ b/examples/modis-061/modis-MOD21A2-061/collection.json
@@ -126,7 +126,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD09A1-061/collection.json
+++ b/examples/modis-061/modis-MYD09A1-061/collection.json
@@ -134,7 +134,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD09Q1-061/collection.json
+++ b/examples/modis-061/modis-MYD09Q1-061/collection.json
@@ -98,7 +98,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD10A1-061/collection.json
+++ b/examples/modis-061/modis-MYD10A1-061/collection.json
@@ -105,7 +105,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD10A2-061/collection.json
+++ b/examples/modis-061/modis-MYD10A2-061/collection.json
@@ -85,7 +85,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD11A1-061/collection.json
+++ b/examples/modis-061/modis-MYD11A1-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD11A2-061/collection.json
+++ b/examples/modis-061/modis-MYD11A2-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD13A1-061/collection.json
+++ b/examples/modis-061/modis-MYD13A1-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD13Q1-061/collection.json
+++ b/examples/modis-061/modis-MYD13Q1-061/collection.json
@@ -130,7 +130,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD14A1-061/collection.json
+++ b/examples/modis-061/modis-MYD14A1-061/collection.json
@@ -98,7 +98,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD14A2-061/collection.json
+++ b/examples/modis-061/modis-MYD14A2-061/collection.json
@@ -90,7 +90,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD15A2H-061/collection.json
+++ b/examples/modis-061/modis-MYD15A2H-061/collection.json
@@ -106,7 +106,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD16A3GF-061/collection.json
+++ b/examples/modis-061/modis-MYD16A3GF-061/collection.json
@@ -102,7 +102,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Water"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD17A2H-061/collection.json
+++ b/examples/modis-061/modis-MYD17A2H-061/collection.json
@@ -94,7 +94,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD17A2HGF-061/collection.json
+++ b/examples/modis-061/modis-MYD17A2HGF-061/collection.json
@@ -94,7 +94,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD17A3HGF-061/collection.json
+++ b/examples/modis-061/modis-MYD17A3HGF-061/collection.json
@@ -94,7 +94,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/examples/modis-061/modis-MYD21A2-061/collection.json
+++ b/examples/modis-061/modis-MYD21A2-061/collection.json
@@ -126,7 +126,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -66,7 +66,7 @@ def create_collection(product: str, version: str) -> Collection:
                                    extent=fragment["extent"],
                                    title=fragment["title"],
                                    providers=fragment["providers"],
-                                   keywords=["modis"],
+                                   keywords=fragment.get("keywords", list()),
                                    summaries=Summaries(summaries))
     collection.add_links(fragment["links"])
 

--- a/tests/data-files/expected/MCD12Q1/006/collection.json
+++ b/tests/data-files/expected/MCD12Q1/006/collection.json
@@ -127,9 +127,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MCD15A2H/061/collection.json
+++ b/tests/data-files/expected/MCD15A2H/061/collection.json
@@ -100,7 +100,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MCD15A3H/061/collection.json
+++ b/tests/data-files/expected/MCD15A3H/061/collection.json
@@ -100,7 +100,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MCD43A4/006/collection.json
+++ b/tests/data-files/expected/MCD43A4/006/collection.json
@@ -138,9 +138,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MCD43A4/061/collection.json
+++ b/tests/data-files/expected/MCD43A4/061/collection.json
@@ -132,7 +132,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MCD64A1/061/collection.json
+++ b/tests/data-files/expected/MCD64A1/061/collection.json
@@ -96,7 +96,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD09A1/061/collection.json
+++ b/tests/data-files/expected/MOD09A1/061/collection.json
@@ -128,7 +128,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD09Q1/061/collection.json
+++ b/tests/data-files/expected/MOD09Q1/061/collection.json
@@ -92,7 +92,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD10A1/006/collection.json
+++ b/tests/data-files/expected/MOD10A1/006/collection.json
@@ -98,9 +98,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA NSIDC DAAC at CIRES",

--- a/tests/data-files/expected/MOD10A1/061/collection.json
+++ b/tests/data-files/expected/MOD10A1/061/collection.json
@@ -99,7 +99,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD10A2/061/collection.json
+++ b/tests/data-files/expected/MOD10A2/061/collection.json
@@ -79,7 +79,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD11A1/006/collection.json
+++ b/tests/data-files/expected/MOD11A1/006/collection.json
@@ -123,9 +123,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD11A1/061/collection.json
+++ b/tests/data-files/expected/MOD11A1/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD11A2/006/collection.json
+++ b/tests/data-files/expected/MOD11A2/006/collection.json
@@ -123,9 +123,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD11A2/061/collection.json
+++ b/tests/data-files/expected/MOD11A2/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD13A1/006/collection.json
+++ b/tests/data-files/expected/MOD13A1/006/collection.json
@@ -127,9 +127,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD13A1/061/collection.json
+++ b/tests/data-files/expected/MOD13A1/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD13Q1/006/collection.json
+++ b/tests/data-files/expected/MOD13Q1/006/collection.json
@@ -127,9 +127,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD13Q1/061/collection.json
+++ b/tests/data-files/expected/MOD13Q1/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD14A1/006/collection.json
+++ b/tests/data-files/expected/MOD14A1/006/collection.json
@@ -91,9 +91,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD14A1/061/collection.json
+++ b/tests/data-files/expected/MOD14A1/061/collection.json
@@ -92,7 +92,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD14A2/006/collection.json
+++ b/tests/data-files/expected/MOD14A2/006/collection.json
@@ -83,9 +83,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD14A2/061/collection.json
+++ b/tests/data-files/expected/MOD14A2/061/collection.json
@@ -84,7 +84,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD15A2H/006/collection.json
+++ b/tests/data-files/expected/MOD15A2H/006/collection.json
@@ -99,9 +99,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD15A2H/061/collection.json
+++ b/tests/data-files/expected/MOD15A2H/061/collection.json
@@ -100,7 +100,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD16A3GF/006/collection.json
+++ b/tests/data-files/expected/MOD16A3GF/006/collection.json
@@ -95,9 +95,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD16A3GF/061/collection.json
+++ b/tests/data-files/expected/MOD16A3GF/061/collection.json
@@ -96,7 +96,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Water"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD17A2H/006/collection.json
+++ b/tests/data-files/expected/MOD17A2H/006/collection.json
@@ -87,9 +87,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD17A2H/061/collection.json
+++ b/tests/data-files/expected/MOD17A2H/061/collection.json
@@ -88,7 +88,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD17A2HGF/006/collection.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/collection.json
@@ -87,9 +87,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD17A2HGF/061/collection.json
+++ b/tests/data-files/expected/MOD17A2HGF/061/collection.json
@@ -88,7 +88,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD17A3HGF/006/collection.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/collection.json
@@ -83,9 +83,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD17A3HGF/061/collection.json
+++ b/tests/data-files/expected/MOD17A3HGF/061/collection.json
@@ -88,7 +88,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD21A2/006/collection.json
+++ b/tests/data-files/expected/MOD21A2/006/collection.json
@@ -119,9 +119,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD21A2/061/collection.json
+++ b/tests/data-files/expected/MOD21A2/061/collection.json
@@ -120,7 +120,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MOD44B/006/collection.json
+++ b/tests/data-files/expected/MOD44B/006/collection.json
@@ -103,9 +103,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MOD44W/006/collection.json
+++ b/tests/data-files/expected/MOD44W/006/collection.json
@@ -78,9 +78,7 @@
     }
   },
   "license": "proprietary",
-  "keywords": [
-    "modis"
-  ],
+  "keywords": [],
   "providers": [
     {
       "name": "NASA LP DAAC at the USGS EROS Center",

--- a/tests/data-files/expected/MYD09A1/061/collection.json
+++ b/tests/data-files/expected/MYD09A1/061/collection.json
@@ -128,7 +128,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD09Q1/061/collection.json
+++ b/tests/data-files/expected/MYD09Q1/061/collection.json
@@ -92,7 +92,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD10A1/061/collection.json
+++ b/tests/data-files/expected/MYD10A1/061/collection.json
@@ -99,7 +99,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD10A2/061/collection.json
+++ b/tests/data-files/expected/MYD10A2/061/collection.json
@@ -79,7 +79,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD11A1/061/collection.json
+++ b/tests/data-files/expected/MYD11A1/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD11A2/061/collection.json
+++ b/tests/data-files/expected/MYD11A2/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD13A1/061/collection.json
+++ b/tests/data-files/expected/MYD13A1/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD13Q1/061/collection.json
+++ b/tests/data-files/expected/MYD13Q1/061/collection.json
@@ -124,7 +124,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Reflectance"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD14A1/061/collection.json
+++ b/tests/data-files/expected/MYD14A1/061/collection.json
@@ -92,7 +92,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD14A2/061/collection.json
+++ b/tests/data-files/expected/MYD14A2/061/collection.json
@@ -84,7 +84,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Fire"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD15A2H/061/collection.json
+++ b/tests/data-files/expected/MYD15A2H/061/collection.json
@@ -100,7 +100,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Forest"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD16A3GF/061/collection.json
+++ b/tests/data-files/expected/MYD16A3GF/061/collection.json
@@ -96,7 +96,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Water"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD17A2H/061/collection.json
+++ b/tests/data-files/expected/MYD17A2H/061/collection.json
@@ -88,7 +88,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD17A2HGF/061/collection.json
+++ b/tests/data-files/expected/MYD17A2HGF/061/collection.json
@@ -88,7 +88,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD17A3HGF/061/collection.json
+++ b/tests/data-files/expected/MYD17A3HGF/061/collection.json
@@ -88,7 +88,12 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global"
   ],
   "providers": [
     {

--- a/tests/data-files/expected/MYD21A2/061/collection.json
+++ b/tests/data-files/expected/MYD21A2/061/collection.json
@@ -120,7 +120,13 @@
   },
   "license": "proprietary",
   "keywords": [
-    "modis"
+    "NASA",
+    "MODIS",
+    "Satellite",
+    "Remote Sensing",
+    "Imagery",
+    "Global",
+    "Temperature"
   ],
   "providers": [
     {


### PR DESCRIPTION
**Related Issue(s):** #54 

**Description:** Keywords from fragments weren't being used when creating collections, they are now.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Example STAC Catalog has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
