### PR TITLE
Switch to builder model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Insert "data" role at the front of the roles list ([#75](https://github.com/stactools-packages/modis/pull/75))
 - Keywords ([#77](https://github.com/stactools-packages/modis/pull/77))
 - Metadata is now a dataclass ([#80](https://github.com/stactools-packages/modis/pull/80))
+- Refactor item creation to use the builder model ([#79](https://github.com/stactools-packages/modis/pull/79))
 
 ### Removed
 

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "id": "modis",
   "stac_version": "1.0.0",
-  "description": "MODIS STAC Catalog containg a subset of MODIS assets",
+  "description": "MODIS STAC Catalog containing a subset of MODIS assets",
   "links": [
     {
       "rel": "root",

--- a/examples/modis-006/catalog.json
+++ b/examples/modis-006/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "id": "modis-006",
   "stac_version": "1.0.0",
-  "description": "MODIS STAC Catalog containg a subset of MODIS assets, version 006",
+  "description": "MODIS STAC Catalog containing a subset of MODIS assets, version 006",
   "links": [
     {
       "rel": "root",

--- a/examples/modis-006/modis-10A1-006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/examples/modis-006/modis-10A1-006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-29T00:00:00Z",
     "end_datetime": "2022-01-29T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-31T04:58:23Z",
     "updated": "2022-01-30T22:03:40.097000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD10A1.A2022029.h10v05.006.2022031045818.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-11A1-006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/examples/modis-006/modis-11A1-006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -21,15 +21,15 @@
     "QC_LST_Error_flag_11": "average LST error > 3K",
     "start_datetime": "2022-01-30T00:00:00Z",
     "end_datetime": "2022-01-30T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-31T09:48:27Z",
     "updated": "2022-01-31T03:53:55.289000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "eo:cloud_cover": 30,
     "datetime": null
   },
@@ -81,20 +81,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD11A1.A2022030.h10v05.006.2022031094827.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-11A2-006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/examples/modis-006/modis-11A2-006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -21,15 +21,15 @@
     "QC_LST_Error_flag_11": "average LST error > 3K",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:57:24Z",
     "updated": "2022-01-26T23:32:16.338000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "eo:cloud_cover": 2,
     "datetime": null
   },
@@ -81,20 +81,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD11A2.A2022017.h10v05.006.2022026205724.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-12Q1-006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/examples/modis-006/modis-12Q1-006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -119,15 +119,15 @@
     "LW_Class_2": "f9ffa4, Land",
     "start_datetime": "2001-01-01T00:00:00Z",
     "end_datetime": "2001-12-31T23:59:59Z",
-    "modis:horizontal-tile": 0,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51000008",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2018-05-22T18:29:03Z",
     "updated": "2019-08-26T14:27:11.357000Z",
+    "modis:horizontal-tile": 0,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51000008",
     "datetime": null
   },
   "geometry": {
@@ -204,20 +204,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-13A1-006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/examples/modis-006/modis-13A1-006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -46,15 +46,15 @@
     "Summary_QA_3": "Cloudy - Target not visible, covered with cloud",
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-01-16T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-18T22:56:31Z",
     "updated": "2022-01-18T17:02:41.699000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "datetime": null
   },
   "geometry": {
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD13A1.A2022001.h09v05.006.2022018175631.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-13Q1-006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/examples/modis-006/modis-13Q1-006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -46,15 +46,15 @@
     "Summary_QA_3": "Cloudy - Target not visible, covered with cloud",
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-01-16T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-18T22:57:46Z",
     "updated": "2022-01-18T17:05:27.039000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "datetime": null
   },
   "geometry": {
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD13Q1.A2022001.h09v05.006.2022018175746.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-14A1-006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/examples/modis-006/modis-14A1-006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -21,15 +21,15 @@
     "QA_bit_2_night_day_1": "Day",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:06.516000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -80,20 +80,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD14A1.A2022017.h10v05.006.2022026155645.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-14A2-006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/examples/modis-006/modis-14A2-006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -21,15 +21,15 @@
     "QA_bit_2_night_day_1": "Day",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:05.772000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -80,20 +80,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD14A2.A2022017.h10v05.006.2022026155645.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-15A2H-006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/examples/modis-006/modis-15A2H-006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -20,15 +20,15 @@
     "STD_LAI_STD_FPAR_fill_value_class_255": "Fill",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:58:20Z",
     "updated": "2022-01-26T23:20:26.941000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -79,20 +79,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD15A2H.A2022017.h10v05.006.2022026205820.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-16A3GF-006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/examples/modis-006/modis-16A3GF-006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -26,15 +26,15 @@
     "ET_QC_500m_fill_value_class_32767": "Fill",
     "start_datetime": "2020-01-01T00:00:00Z",
     "end_datetime": "2020-12-31T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-11T23:41:47Z",
     "updated": "2022-01-11T17:46:28.061000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -85,20 +85,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-17A2H-006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/examples/modis-006/modis-17A2H-006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -27,15 +27,15 @@
     "SCF_QC_100": "4, Pixel not produced at all, value coudn't be retrieved(possible reasons: bad L1B data, unusable MOD09GA data)",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T22:24:24Z",
     "updated": "2022-01-27T01:09:02.847000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -86,20 +86,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD17A2H.A2022017.h09v04.006.2022026222424.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-17A2HGF-006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/examples/modis-006/modis-17A2HGF-006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -27,15 +27,15 @@
     "SCF_QC_100": "4, Pixel not produced at all, value coudn't be retrieved (possible reasons: badL1B data, unusable MOD09GA data)",
     "start_datetime": "2021-12-03T00:00:00Z",
     "end_datetime": "2021-12-10T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-31T14:10:00Z",
     "updated": "2022-01-31T08:16:07.542000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "datetime": null
   },
   "geometry": {
@@ -86,20 +86,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-17A3HGF-006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/examples/modis-006/modis-17A3HGF-006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -19,15 +19,15 @@
     "Npp_500m_fill_value_class_255": "Fill",
     "start_datetime": "2020-01-01T00:00:00Z",
     "end_datetime": "2020-12-31T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2021-04-23T15:01:37Z",
     "updated": "2021-04-23T10:04:29.686000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -78,20 +78,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-21A2-006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/examples/modis-006/modis-21A2-006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -37,15 +37,15 @@
     "QC_LST_accuracy_11": "<1 K (Excellent performance)",
     "start_datetime": "2005-12-27T00:00:00Z",
     "end_datetime": "2005-12-31T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51010004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2018-10-13T18:15:06Z",
     "updated": "2018-10-14T20:17:00.495000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51010004",
     "eo:cloud_cover": 40,
     "datetime": null
   },
@@ -97,20 +97,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD21A2.A2005361.h10v04.006.2018286181506.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-43A4-006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/examples/modis-006/modis-43A4-006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-11T00:00:00Z",
     "end_datetime": "2022-01-26T23:59:59.999999Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51010004",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-01-28T11:20:24Z",
     "updated": "2022-01-28T05:33:06.715000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51010004",
     "eo:cloud_cover": 34,
     "datetime": "2022-01-19T00:00:00Z"
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MCD43A4.A2022019.h10v04.006.2022028111747.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-44B-006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/examples/modis-006/modis-44B-006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -21,15 +21,15 @@
     "Quality_7_DOY_033_to_045": "0 Clear; 1 Bad",
     "start_datetime": "2020-03-05T00:00:00Z",
     "end_datetime": "2021-03-06T00:00:00Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2021-06-04T15:56:36Z",
     "updated": "2021-06-04T11:50:13.011000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -80,20 +80,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD44B.A2020065.h09v04.006.2021155155636.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD44B.A2020065.h09v04.006.2021155155636.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD44B.A2020065.h09v04.006.2021155155636.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-006/modis-44W-006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/examples/modis-006/modis-44W-006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -17,15 +17,15 @@
     "QA_10": "Fill - outside of projected area",
     "start_datetime": "2015-01-01T00:00:00Z",
     "end_datetime": "2015-12-31T00:00:00Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51010004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2018-02-02T15:02:44Z",
     "updated": "2018-04-04T12:07:35.020000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51010004",
     "datetime": null
   },
   "geometry": {
@@ -76,20 +76,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/MOD44W.A2015001.h10v04.006.2018033150244.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/MOD44W.A2015001.h10v04.006.2018033150244.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/MOD44W.A2015001.h10v04.006.2018033150244.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/examples/modis-061/catalog.json
+++ b/examples/modis-061/catalog.json
@@ -2,7 +2,7 @@
   "type": "Catalog",
   "id": "modis-061",
   "stac_version": "1.0.0",
-  "description": "MODIS STAC Catalog containg a subset of MODIS assets, version 061",
+  "description": "MODIS STAC Catalog containing a subset of MODIS assets, version 061",
   "links": [
     {
       "rel": "root",

--- a/examples/modis-061/modis-09A1-061/MOD09A1.A2022033.h19v10.061.2022042043514/MOD09A1.A2022033.h19v10.061.2022042043514.json
+++ b/examples/modis-061/modis-09A1-061/MOD09A1.A2022033.h19v10.061.2022042043514/MOD09A1.A2022033.h19v10.061.2022042043514.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 19,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51019010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:35:14Z",
     "updated": "2022-02-10T22:44:13.607000Z",
+    "modis:horizontal-tile": 19,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51019010",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165274999,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165274999,
       -1111950.519667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "sur_refl_b04": {

--- a/examples/modis-061/modis-09A1-061/MYD09A1.A2022025.h09v08.061.2022035070021/MYD09A1.A2022025.h09v08.061.2022035070021.json
+++ b/examples/modis-061/modis-09A1-061/MYD09A1.A2022025.h09v08.061.2022035070021/MYD09A1.A2022025.h09v08.061.2022035070021.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51009008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:00:21Z",
     "updated": "2022-02-04T01:11:00.763000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51009008",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       1111950.519667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "sur_refl_state_500m": {

--- a/examples/modis-061/modis-09Q1-061/MOD09Q1.A2022033.h10v10.061.2022042044048/MOD09Q1.A2022033.h10v10.061.2022042044048.json
+++ b/examples/modis-061/modis-09Q1-061/MOD09Q1.A2022033.h10v10.061.2022042044048/MOD09Q1.A2022033.h10v10.061.2022042044048.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51010010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:40:48Z",
     "updated": "2022-02-10T22:51:55.839000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51010010",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      4800,
+      4800
+    ],
     "proj:transform": [
       231.65635826374987,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -231.65635826374995,
       -1111950.519667
-    ],
-    "proj:shape": [
-      4800,
-      4800
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "sur_refl_b02": {

--- a/examples/modis-061/modis-09Q1-061/MYD09Q1.A2022025.h02v08.061.2022035050917/MYD09Q1.A2022025.h02v08.061.2022035050917.json
+++ b/examples/modis-061/modis-09Q1-061/MYD09Q1.A2022025.h02v08.061.2022035050917/MYD09Q1.A2022025.h02v08.061.2022035050917.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 2,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51002008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:09:17Z",
     "updated": "2022-02-03T23:16:45.440000Z",
+    "modis:horizontal-tile": 2,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51002008",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      4800,
+      4800
+    ],
     "proj:transform": [
       231.65635826395862,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -231.65635826395834,
       1111950.519667
-    ],
-    "proj:shape": [
-      4800,
-      4800
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "sur_refl_state_250m": {

--- a/examples/modis-061/modis-10A1-061/MOD10A1.A2022040.h11v05.061.2022042042026/MOD10A1.A2022040.h11v05.061.2022042042026.json
+++ b/examples/modis-061/modis-10A1-061/MOD10A1.A2022040.h11v05.061.2022042042026/MOD10A1.A2022040.h11v05.061.2022042042026.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-09T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51011005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:20:28Z",
     "updated": "2022-02-10T21:25:29.136000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51011005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279169,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "granule_pnt": {

--- a/examples/modis-061/modis-10A1-061/MYD10A1.A2022043.h21v04.061.2022045035657/MYD10A1.A2022043.h21v04.061.2022045035657.json
+++ b/examples/modis-061/modis-10A1-061/MYD10A1.A2022043.h21v04.061.2022045035657/MYD10A1.A2022043.h21v04.061.2022045035657.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-12T00:00:00Z",
     "end_datetime": "2022-02-12T23:59:59Z",
-    "modis:horizontal-tile": 21,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51021004",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-14T03:57:02Z",
     "updated": "2022-02-13T21:01:32.595000Z",
+    "modis:horizontal-tile": 21,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51021004",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279167,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.31271652750013,
       5559752.598333
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Snow_Albedo_Daily_Tile": {

--- a/examples/modis-061/modis-10A1-061/MYD10A1.A2022059.h09v05.061.2022061043435/MYD10A1.A2022059.h09v05.061.2022061043435.json
+++ b/examples/modis-061/modis-10A1-061/MYD10A1.A2022059.h09v05.061.2022061043435/MYD10A1.A2022059.h09v05.061.2022061043435.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-28T00:00:00Z",
     "end_datetime": "2022-02-28T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-03-02T04:34:42Z",
     "updated": "2022-03-01T21:38:26.845000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD10A1.A2022059.h09v05.061.2022061043435.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD10A1.A2022059.h09v05.061.2022061043435.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022059.h09v05.061.2022061043435.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "orbit_pnt": {

--- a/examples/modis-061/modis-10A2-061/MOD10A2.A2022033.h09v05.061.2022042050729/MOD10A2.A2022033.h09v05.061.2022042050729.json
+++ b/examples/modis-061/modis-10A2-061/MOD10A2.A2022033.h09v05.061.2022042050729/MOD10A2.A2022033.h09v05.061.2022042050729.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T05:07:40Z",
     "updated": "2022-02-10T22:17:10.512000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD10A2.A2022033.h09v05.061.2022042050729.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD10A2.A2022033.h09v05.061.2022042050729.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD10A2.A2022033.h09v05.061.2022042050729.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Eight_Day_Snow_Cover": {

--- a/examples/modis-061/modis-10A2-061/MYD10A2.A2022025.h10v05.061.2022035071201/MYD10A2.A2022025.h10v05.061.2022035071201.json
+++ b/examples/modis-061/modis-10A2-061/MYD10A2.A2022025.h10v05.061.2022035071201/MYD10A2.A2022025.h10v05.061.2022035071201.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:12:12Z",
     "updated": "2022-02-04T00:16:00.600000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652749973,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD10A2.A2022025.h10v05.061.2022035071201.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD10A2.A2022025.h10v05.061.2022035071201.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD10A2.A2022025.h10v05.061.2022035071201.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Eight_Day_Snow_Cover": {

--- a/examples/modis-061/modis-11A1-061/MOD11A1.A2022041.h19v02.061.2022042095544/MOD11A1.A2022041.h19v02.061.2022042095544.json
+++ b/examples/modis-061/modis-11A1-061/MOD11A1.A2022041.h19v02.061.2022042095544/MOD11A1.A2022041.h19v02.061.2022042095544.json
@@ -5,18 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-10T00:00:00Z",
     "end_datetime": "2022-02-10T23:59:59Z",
-    "modis:horizontal-tile": 19,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51019002",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T09:55:44Z",
     "updated": "2022-02-11T04:04:50.881000Z",
-    "eo:cloud_cover": 49,
+    "modis:horizontal-tile": 19,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51019002",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -44,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254331383333,
       0.0,
@@ -52,10 +55,7 @@
       -926.6254331391661,
       7783653.638366
     ],
-    "proj:shape": [
-      1200,
-      1200
-    ],
+    "eo:cloud_cover": 49,
     "datetime": null
   },
   "geometry": {
@@ -106,20 +106,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "QC_Day": {
@@ -314,8 +314,8 @@
     69.9958333333333
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
   ],
   "collection": "modis-11A1-061"

--- a/examples/modis-061/modis-11A1-061/MYD11A1.A2022039.h21v07.061.2022040192419/MYD11A1.A2022039.h21v07.061.2022040192419.json
+++ b/examples/modis-061/modis-11A1-061/MYD11A1.A2022039.h21v07.061.2022040192419/MYD11A1.A2022039.h21v07.061.2022040192419.json
@@ -5,18 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-08T00:00:00Z",
     "end_datetime": "2022-02-08T23:59:59Z",
-    "modis:horizontal-tile": 21,
-    "modis:vertical-tile": 7,
-    "modis:tile-id": "51021007",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-09T19:24:19Z",
     "updated": "2022-02-09T13:45:39.603000Z",
-    "eo:cloud_cover": 11,
+    "modis:horizontal-tile": 21,
+    "modis:vertical-tile": 7,
+    "modis:tile-id": "51021007",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -44,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254331383334,
       0.0,
@@ -52,10 +55,7 @@
       -926.6254331383333,
       2223901.039533
     ],
-    "proj:shape": [
-      1200,
-      1200
-    ],
+    "eo:cloud_cover": 11,
     "datetime": null
   },
   "geometry": {
@@ -106,20 +106,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Day_view_time": {
@@ -314,8 +314,8 @@
     19.9958333333333
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
   ],
   "collection": "modis-11A1-061"

--- a/examples/modis-061/modis-11A2-061/MOD11A2.A2022033.h19v10.061.2022042044121/MOD11A2.A2022033.h19v10.061.2022042044121.json
+++ b/examples/modis-061/modis-11A2-061/MOD11A2.A2022033.h19v10.061.2022042044121/MOD11A2.A2022033.h19v10.061.2022042044121.json
@@ -5,18 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 19,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51019010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:41:21Z",
     "updated": "2022-02-10T22:57:48.564000Z",
-    "eo:cloud_cover": 19,
+    "modis:horizontal-tile": 19,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51019010",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -44,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254331383333,
       0.0,
@@ -52,10 +55,7 @@
       -926.6254331383333,
       -1111950.519767
     ],
-    "proj:shape": [
-      1200,
-      1200
-    ],
+    "eo:cloud_cover": 19,
     "datetime": null
   },
   "geometry": {
@@ -106,20 +106,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "QC_Night": {
@@ -312,8 +312,8 @@
     -10.0041666666667
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
   ],
   "collection": "modis-11A2-061"

--- a/examples/modis-061/modis-11A2-061/MYD11A2.A2022025.h17v00.061.2022035054130/MYD11A2.A2022025.h17v00.061.2022035054130.json
+++ b/examples/modis-061/modis-11A2-061/MYD11A2.A2022025.h17v00.061.2022035054130/MYD11A2.A2022025.h17v00.061.2022035054130.json
@@ -5,18 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 17,
-    "modis:vertical-tile": 0,
-    "modis:tile-id": "51017000",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:41:30Z",
     "updated": "2022-02-03T23:51:17.900000Z",
-    "eo:cloud_cover": 16,
+    "modis:horizontal-tile": 17,
+    "modis:vertical-tile": 0,
+    "modis:tile-id": "51017000",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -44,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254331391667,
       0.0,
@@ -52,10 +55,7 @@
       -926.6254331391661,
       10007554.677899
     ],
-    "proj:shape": [
-      1200,
-      1200
-    ],
+    "eo:cloud_cover": 16,
     "datetime": null
   },
   "geometry": {
@@ -106,20 +106,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Night_view_angl": {
@@ -312,8 +312,8 @@
     89.9875
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
   ],
   "collection": "modis-11A2-061"

--- a/examples/modis-061/modis-13A1-061/MOD13A1.A2022017.h12v11.061.2022034232214/MOD13A1.A2022017.h12v11.061.2022034232214.json
+++ b/examples/modis-061/modis-13A1-061/MOD13A1.A2022017.h12v11.061.2022034232214/MOD13A1.A2022017.h12v11.061.2022034232214.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 11,
-    "modis:tile-id": "51012011",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-04T04:22:14Z",
     "updated": "2022-02-03T22:31:06.875000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 11,
+    "modis:tile-id": "51012011",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       -2223901.039333
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "500m_16_days_composite_day_of_the_year": {

--- a/examples/modis-061/modis-13A1-061/MYD13A1.A2022009.h25v02.061.2022028071925/MYD13A1.A2022009.h25v02.061.2022028071925.json
+++ b/examples/modis-061/modis-13A1-061/MYD13A1.A2022009.h25v02.061.2022028071925/MYD13A1.A2022009.h25v02.061.2022028071925.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-09T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 25,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51025002",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-28T12:19:25Z",
     "updated": "2022-01-28T06:24:44.574000Z",
+    "modis:horizontal-tile": 25,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51025002",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652749973,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279169,
       7783653.637667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -131,20 +131,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "500m_16_days_view_zenith_angle": {

--- a/examples/modis-061/modis-13A1-061/MYD13A1.A2022041.h09v05.061.2022059190534/MYD13A1.A2022041.h09v05.061.2022059190534.json
+++ b/examples/modis-061/modis-13A1-061/MYD13A1.A2022041.h09v05.061.2022059190534/MYD13A1.A2022041.h09v05.061.2022059190534.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-10T00:00:00Z",
     "end_datetime": "2022-02-25T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-03-01T00:05:34Z",
     "updated": "2022-02-28T18:20:23.031000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD13A1.A2022041.h09v05.061.2022059190534.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD13A1.A2022041.h09v05.061.2022059190534.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022041.h09v05.061.2022059190534.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "500m_16_days_NDVI": {

--- a/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022017.h12v11.061.2022034232400/MOD13Q1.A2022017.h12v11.061.2022034232400.json
+++ b/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022017.h12v11.061.2022034232400/MOD13Q1.A2022017.h12v11.061.2022034232400.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 11,
-    "modis:tile-id": "51012011",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-04T04:24:00Z",
     "updated": "2022-02-03T22:37:17.991000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 11,
+    "modis:tile-id": "51012011",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      4800,
+      4800
+    ],
     "proj:transform": [
       231.65635826395825,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -231.65635826395834,
       -2223901.039333
-    ],
-    "proj:shape": [
-      4800,
-      4800
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "250m_16_days_NDVI": {

--- a/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022033.h09v05.061.2022051005101/MOD13Q1.A2022033.h09v05.061.2022051005101.json
+++ b/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022033.h09v05.061.2022051005101/MOD13Q1.A2022033.h09v05.061.2022051005101.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-17T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-20T05:51:01Z",
     "updated": "2022-02-20T03:40:18.704000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      4800,
+      4800
+    ],
     "proj:transform": [
       231.65635826395825,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -231.65635826395834,
       4447802.078667
-    ],
-    "proj:shape": [
-      4800,
-      4800
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD13Q1.A2022033.h09v05.061.2022051005101.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD13Q1.A2022033.h09v05.061.2022051005101.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022033.h09v05.061.2022051005101.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "250m_16_days_NIR_reflectance": {

--- a/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022009.h09v06.061.2022028072010/MYD13Q1.A2022009.h09v06.061.2022028072010.json
+++ b/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022009.h09v06.061.2022028072010/MYD13Q1.A2022009.h09v06.061.2022028072010.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-09T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51009006",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-28T12:20:10Z",
     "updated": "2022-01-28T06:31:42.841000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51009006",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      4800,
+      4800
+    ],
     "proj:transform": [
       231.65635826395825,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -231.65635826395834,
       3335851.559
-    ],
-    "proj:shape": [
-      4800,
-      4800
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "250m_16_days_blue_reflectance": {

--- a/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022041.h09v05.061.2022059190716/MYD13Q1.A2022041.h09v05.061.2022059190716.json
+++ b/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022041.h09v05.061.2022059190716/MYD13Q1.A2022041.h09v05.061.2022059190716.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-10T00:00:00Z",
     "end_datetime": "2022-02-25T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-03-01T00:07:16Z",
     "updated": "2022-02-28T21:17:04.494000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      4800,
+      4800
+    ],
     "proj:transform": [
       231.65635826395825,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -231.65635826395834,
       4447802.078667
-    ],
-    "proj:shape": [
-      4800,
-      4800
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD13Q1.A2022041.h09v05.061.2022059190716.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD13Q1.A2022041.h09v05.061.2022059190716.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022041.h09v05.061.2022059190716.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "250m_16_days_NIR_reflectance": {

--- a/examples/modis-061/modis-14A1-061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
+++ b/examples/modis-061/modis-14A1-061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51011005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:47:59Z",
     "updated": "2022-02-10T22:59:34.540000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51011005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254330558338,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330558334,
       4447802.078667
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "MaxFRP": {

--- a/examples/modis-061/modis-14A1-061/MOD14A1.A2022049.h09v05.061.2022057235503/MOD14A1.A2022049.h09v05.061.2022057235503.json
+++ b/examples/modis-061/modis-14A1-061/MOD14A1.A2022049.h09v05.061.2022057235503/MOD14A1.A2022049.h09v05.061.2022057235503.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-18T00:00:00Z",
     "end_datetime": "2022-02-25T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-27T04:55:03Z",
     "updated": "2022-02-26T22:59:10.256000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.625433055833,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330558334,
       4447802.078667
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD14A1.A2022049.h09v05.061.2022057235503.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD14A1.A2022049.h09v05.061.2022057235503.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD14A1.A2022049.h09v05.061.2022057235503.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "MaxFRP": {

--- a/examples/modis-061/modis-14A1-061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
+++ b/examples/modis-061/modis-14A1-061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 1,
-    "modis:vertical-tile": 7,
-    "modis:tile-id": "51001007",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:11:41Z",
     "updated": "2022-02-03T23:40:07.931000Z",
+    "modis:horizontal-tile": 1,
+    "modis:vertical-tile": 7,
+    "modis:tile-id": "51001007",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254330549979,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330549998,
       2223901.039333
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -131,20 +131,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "MaxFRP": {

--- a/examples/modis-061/modis-14A1-061/MYD14A1.A2022049.h09v05.061.2022057234556/MYD14A1.A2022049.h09v05.061.2022057234556.json
+++ b/examples/modis-061/modis-14A1-061/MYD14A1.A2022049.h09v05.061.2022057234556/MYD14A1.A2022049.h09v05.061.2022057234556.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-18T00:00:00Z",
     "end_datetime": "2022-02-25T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-27T04:45:56Z",
     "updated": "2022-02-27T02:56:21.003000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.625433055833,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330558334,
       4447802.078667
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD14A1.A2022049.h09v05.061.2022057234556.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD14A1.A2022049.h09v05.061.2022057234556.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD14A1.A2022049.h09v05.061.2022057234556.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "QA": {

--- a/examples/modis-061/modis-14A2-061/MOD14A2.A2022033.h21v05.061.2022041234800/MOD14A2.A2022033.h21v05.061.2022041234800.json
+++ b/examples/modis-061/modis-14A2-061/MOD14A2.A2022033.h21v05.061.2022041234800/MOD14A2.A2022033.h21v05.061.2022041234800.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 21,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51021005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:48:00Z",
     "updated": "2022-02-10T23:01:33.748000Z",
+    "modis:horizontal-tile": 21,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51021005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254330558334,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330558334,
       4447802.078667
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD14A2.A2022033.h21v05.061.2022041234800.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD14A2.A2022033.h21v05.061.2022041234800.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD14A2.A2022033.h21v05.061.2022041234800.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "FireMask": {

--- a/examples/modis-061/modis-14A2-061/MYD14A2.A2022025.h03v09.061.2022035001140/MYD14A2.A2022025.h03v09.061.2022035001140.json
+++ b/examples/modis-061/modis-14A2-061/MYD14A2.A2022025.h03v09.061.2022035001140/MYD14A2.A2022025.h03v09.061.2022035001140.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 3,
-    "modis:vertical-tile": 9,
-    "modis:tile-id": "51003009",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:11:40Z",
     "updated": "2022-02-03T23:23:11.946000Z",
+    "modis:horizontal-tile": 3,
+    "modis:vertical-tile": 9,
+    "modis:tile-id": "51003009",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.625433055833,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330558334,
       0.0
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD14A2.A2022025.h03v09.061.2022035001140.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD14A2.A2022025.h03v09.061.2022035001140.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD14A2.A2022025.h03v09.061.2022035001140.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "QA": {

--- a/examples/modis-061/modis-15A2H-061/MCD15A2H.A2022025.h01v11.061.2022035062702/MCD15A2H.A2022025.h01v11.061.2022035062702.json
+++ b/examples/modis-061/modis-15A2H-061/MCD15A2H.A2022025.h01v11.061.2022035062702/MCD15A2H.A2022025.h01v11.061.2022035062702.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 1,
-    "modis:vertical-tile": 11,
-    "modis:tile-id": "51001011",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-04T06:27:02Z",
     "updated": "2022-02-04T00:36:19.295000Z",
+    "modis:horizontal-tile": 1,
+    "modis:vertical-tile": 11,
+    "modis:tile-id": "51001011",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652749894,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       -2223901.039333
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -131,20 +131,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "FparLai_QC": {

--- a/examples/modis-061/modis-15A2H-061/MOD15A2H.A2022033.h13v10.061.2022042045937/MOD15A2H.A2022033.h13v10.061.2022042045937.json
+++ b/examples/modis-061/modis-15A2H-061/MOD15A2H.A2022033.h13v10.061.2022042045937/MOD15A2H.A2022033.h13v10.061.2022042045937.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 13,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51013010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:59:37Z",
     "updated": "2022-02-10T23:09:54.486000Z",
+    "modis:horizontal-tile": 13,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51013010",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652750013,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165274999,
       -1111950.519667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "FparStdDev_500m": {

--- a/examples/modis-061/modis-15A2H-061/MYD15A2H.A2022025.h22v08.061.2022035072026/MYD15A2H.A2022025.h22v08.061.2022035072026.json
+++ b/examples/modis-061/modis-15A2H-061/MYD15A2H.A2022025.h22v08.061.2022035072026/MYD15A2H.A2022025.h22v08.061.2022035072026.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 22,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51022008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:20:26Z",
     "updated": "2022-02-04T01:26:04.137000Z",
+    "modis:horizontal-tile": 22,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51022008",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652750013,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       1111950.519667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "FparStdDev_500m": {

--- a/examples/modis-061/modis-15A3H-061/MCD15A3H.A2022033.h12v10.061.2022039062215/MCD15A3H.A2022033.h12v10.061.2022039062215.json
+++ b/examples/modis-061/modis-15A3H-061/MCD15A3H.A2022033.h12v10.061.2022039062215/MCD15A3H.A2022033.h12v10.061.2022039062215.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-05T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51012010",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-08T06:22:15Z",
     "updated": "2022-02-08T00:30:21.656000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51012010",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165274999,
       -1111950.519667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Fpar_500m": {

--- a/examples/modis-061/modis-16A3GF-061/MOD16A3GF.A2021001.h11v02.061.2022024075208/MOD16A3GF.A2021001.h11v02.061.2022024075208.json
+++ b/examples/modis-061/modis-16A3GF-061/MOD16A3GF.A2021001.h11v02.061.2022024075208/MOD16A3GF.A2021001.h11v02.061.2022024075208.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51011002",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-24T12:53:25Z",
     "updated": "2022-01-24T06:56:49.574000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51011002",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279169,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279169,
       7783653.637667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -131,20 +131,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "PLE_500m": {

--- a/examples/modis-061/modis-16A3GF-061/MYD16A3GF.A2021001.h11v02.061.2022024220526/MYD16A3GF.A2021001.h11v02.061.2022024220526.json
+++ b/examples/modis-061/modis-16A3GF-061/MYD16A3GF.A2021001.h11v02.061.2022024220526/MYD16A3GF.A2021001.h11v02.061.2022024220526.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51011002",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-25T03:06:08Z",
     "updated": "2022-01-24T21:08:56.273000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51011002",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279169,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279169,
       7783653.637667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -131,20 +131,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "ET_500m": {

--- a/examples/modis-061/modis-17A2H-061/MOD17A2H.A2022025.h08v05.061.2022035065002/MOD17A2H.A2022025.h08v05.061.2022035065002.json
+++ b/examples/modis-061/modis-17A2H-061/MOD17A2H.A2022025.h08v05.061.2022035065002/MOD17A2H.A2022025.h08v05.061.2022035065002.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 8,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51008005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-04T06:50:02Z",
     "updated": "2022-02-04T01:03:18.424000Z",
+    "modis:horizontal-tile": 8,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51008005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652791725,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Psn_QC_500m": {

--- a/examples/modis-061/modis-17A2H-061/MYD17A2H.A2022025.h22v08.061.2022035120601/MYD17A2H.A2022025.h22v08.061.2022035120601.json
+++ b/examples/modis-061/modis-17A2H-061/MYD17A2H.A2022025.h22v08.061.2022035120601/MYD17A2H.A2022025.h22v08.061.2022035120601.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 22,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51022008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T12:06:01Z",
     "updated": "2022-02-04T06:17:56.444000Z",
+    "modis:horizontal-tile": 22,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51022008",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652750013,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       1111950.519667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Psn_QC_500m": {

--- a/examples/modis-061/modis-17A2HGF-061/MOD17A2HGF.A2021361.h10v06.061.2022020134637/MOD17A2HGF.A2021361.h10v06.061.2022020134637.json
+++ b/examples/modis-061/modis-17A2HGF-061/MOD17A2HGF.A2021361.h10v06.061.2022020134637/MOD17A2HGF.A2021361.h10v06.061.2022020134637.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-12-27T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51010006",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-20T13:46:37Z",
     "updated": "2022-01-20T07:50:11.257000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51010006",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652749973,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       3335851.559
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "PsnNet_500m": {

--- a/examples/modis-061/modis-17A2HGF-061/MYD17A2HGF.A2021361.h13v09.061.2022021010829/MYD17A2HGF.A2021361.h13v09.061.2022021010829.json
+++ b/examples/modis-061/modis-17A2HGF-061/MYD17A2HGF.A2021361.h13v09.061.2022021010829/MYD17A2HGF.A2021361.h13v09.061.2022021010829.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-12-27T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 13,
-    "modis:vertical-tile": 9,
-    "modis:tile-id": "51013009",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-21T01:08:29Z",
     "updated": "2022-01-20T19:12:09.442000Z",
+    "modis:horizontal-tile": 13,
+    "modis:vertical-tile": 9,
+    "modis:tile-id": "51013009",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652750013,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       0.0
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Psn_QC_500m": {

--- a/examples/modis-061/modis-17A3HGF-061/MOD17A3HGF.A2021001.h14v02.061.2022020135800/MOD17A3HGF.A2021001.h14v02.061.2022020135800.json
+++ b/examples/modis-061/modis-17A3HGF-061/MOD17A3HGF.A2021001.h14v02.061.2022020135800/MOD17A3HGF.A2021001.h14v02.061.2022020135800.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 14,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51014002",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-20T13:58:00Z",
     "updated": "2022-01-20T08:00:08.259000Z",
+    "modis:horizontal-tile": 14,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51014002",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279167,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279169,
       7783653.637667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Npp_QC_500m": {

--- a/examples/modis-061/modis-17A3HGF-061/MYD17A3HGF.A2021001.h13v09.061.2022021012736/MYD17A3HGF.A2021001.h13v09.061.2022021012736.json
+++ b/examples/modis-061/modis-17A3HGF-061/MYD17A3HGF.A2021001.h13v09.061.2022021012736/MYD17A3HGF.A2021001.h13v09.061.2022021012736.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 13,
-    "modis:vertical-tile": 9,
-    "modis:tile-id": "51013009",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-21T01:27:36Z",
     "updated": "2022-01-20T19:30:15.987000Z",
+    "modis:horizontal-tile": 13,
+    "modis:vertical-tile": 9,
+    "modis:tile-id": "51013009",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.31271652750013,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       0.0
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Gpp_500m": {

--- a/examples/modis-061/modis-21A2-061/MOD21A2.A2022033.h12v08.061.2022042050733/MOD21A2.A2022033.h12v08.061.2022042050733.json
+++ b/examples/modis-061/modis-21A2-061/MOD21A2.A2022033.h12v08.061.2022042050733/MOD21A2.A2022033.h12v08.061.2022042050733.json
@@ -5,18 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51012008",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T05:07:33Z",
     "updated": "2022-02-10T23:11:39.276000Z",
-    "eo:cloud_cover": 36,
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51012008",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -44,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.625433055833,
       0.0,
@@ -52,10 +55,7 @@
       -926.6254330558334,
       1111950.519667
     ],
-    "proj:shape": [
-      1200,
-      1200
-    ],
+    "eo:cloud_cover": 36,
     "datetime": null
   },
   "geometry": {
@@ -106,20 +106,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Emis_32": {
@@ -297,8 +297,8 @@
     10.0046098963972
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
   ],
   "collection": "modis-21A2-061"

--- a/examples/modis-061/modis-21A2-061/MYD21A2.A2022025.h10v06.061.2022035072054/MYD21A2.A2022025.h10v06.061.2022035072054.json
+++ b/examples/modis-061/modis-21A2-061/MYD21A2.A2022025.h10v06.061.2022035072054/MYD21A2.A2022025.h10v06.061.2022035072054.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51010006",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:20:54Z",
     "updated": "2022-02-04T01:25:32.670000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51010006",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      1200,
+      1200
+    ],
     "proj:transform": [
       926.6254330549995,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -926.6254330558334,
       3335851.559
-    ],
-    "proj:shape": [
-      1200,
-      1200
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Emis_29": {

--- a/examples/modis-061/modis-43A4-061/MCD43A4.A2022032.h14v10.061.2022041051831/MCD43A4.A2022032.h14v10.061.2022041051831.json
+++ b/examples/modis-061/modis-43A4-061/MCD43A4.A2022032.h14v10.061.2022041051831/MCD43A4.A2022032.h14v10.061.2022041051831.json
@@ -5,18 +5,17 @@
   "properties": {
     "start_datetime": "2022-01-24T00:00:00Z",
     "end_datetime": "2022-02-08T23:59:59.999999Z",
-    "modis:horizontal-tile": 14,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51014010",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-10T05:19:45Z",
     "updated": "2022-02-09T23:25:46.095000Z",
-    "eo:cloud_cover": 10,
+    "modis:horizontal-tile": 14,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51014010",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -44,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279167,
       0.0,
@@ -52,10 +55,7 @@
       -463.3127165274999,
       -1111950.519667
     ],
-    "proj:shape": [
-      2400,
-      2400
-    ],
+    "eo:cloud_cover": 10,
     "datetime": "2022-02-01T00:00:00Z"
   },
   "geometry": {
@@ -106,20 +106,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "BRDF_Albedo_Band_Mandatory_Quality_Band4": {
@@ -501,8 +501,8 @@
     -9.95544626171462
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
   ],

--- a/examples/modis-061/modis-64A1-061/MCD64A1.A2021335.h10v06.061.2022035055453/MCD64A1.A2021335.h10v06.061.2022035055453.json
+++ b/examples/modis-061/modis-64A1-061/MCD64A1.A2021335.h10v06.061.2022035055453/MCD64A1.A2021335.h10v06.061.2022035055453.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2021-12-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51010006",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-04T10:54:53Z",
     "updated": "2022-02-04T04:59:11.327000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51010006",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279169,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       3335851.558997
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "First_Day": {

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,3 +16,6 @@ ignore_missing_imports = True
 
 [mypy-lxml.*]
 ignore_missing_imports = True
+
+[mypy-multihash.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,14 @@ include_package_data = True
 package_dir =
     = src
 packages = 
+    stactools.builder
     stactools.modis
     stactools.modis.fragments
 install_requires =
     stactools >= 0.3.0
     click != 8.1.0
+    py-multihash >= 2.0.1
+
 
 [options.packages.find]
 where = src

--- a/src/stactools/builder/__init__.py
+++ b/src/stactools/builder/__init__.py
@@ -1,0 +1,595 @@
+import datetime
+import hashlib
+import os.path
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, cast
+
+import fsspec
+import multihash
+import rasterio
+import shapely.geometry
+import stactools.core.projection
+import stactools.core.utils.antimeridian
+import stactools.core.utils.convert
+from pystac import Asset, Item, MediaType
+from pystac.extensions.eo import AssetEOExtension, EOExtension
+from pystac.extensions.file import FileExtension
+from pystac.extensions.projection import AssetProjectionExtension, ProjectionExtension
+from pystac.extensions.raster import RasterBand, RasterExtension
+from rasterio.crs import CRSError
+from stactools.core.io import ReadHrefModifier
+from stactools.core.utils.antimeridian import Strategy
+
+EPSG = 4326
+CLASSIFICATION_EXTENSION_HREF = (
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+)
+DEFAULT_ANTIMERIDIAN_STRATEGY = Strategy.SPLIT
+Object = Dict[str, Any]
+
+
+@dataclass
+class AssetInfo:
+    """Information about an asset.
+
+    This is a "light" version of an actual PySTAC asset.
+    """
+
+    geometry: Optional[Object]
+    """An optional WGS84 geometry for this asset."""
+
+    projection: Optional[Object]
+    """Optional projection information that will be used for the projection extension."""
+
+    raster: Optional[Object]
+    """Optional raster information that will be used for the raster extension."""
+
+    eo: Optional[Object]
+    """Optional information for the eo extension."""
+
+    classification: Optional[Object]
+    """Optional information for the classification extension."""
+
+    calculate_file_info: bool
+    """Should file info be calculated for this asset (requires reading the whole file)."""
+
+    extra_fields: Object
+    """Any extra fields to include on the asset."""
+
+
+@dataclass
+class ItemInfo:
+    """Information about an item.
+
+    This is a "light" version of an actual PySTAC Item.
+    """
+
+    id: str
+    """The item's id."""
+
+    geometry: Optional[Object]
+    """The item's geometry."""
+
+    datetime: Optional[datetime.datetime]
+    """The item's datetime."""
+
+    properties: Object
+    """The item's properties."""
+
+    projection: Optional[Object]
+    """The item's projection information, that will be used for the projection extension."""
+
+    eo: Optional[Object]
+    """Optional EO information for the item."""
+
+    asset_infos: Dict[str, AssetInfo]
+    """Information about the item's assets."""
+
+
+@dataclass
+class FileInfo:
+    """Information about a file, for use with the file extension."""
+
+    checksum: str
+    """The file's multihash encoded digest."""
+
+    size: int
+    """The size of the file in bytes."""
+
+    @classmethod
+    def read(cls, href: str) -> "FileInfo":
+        """Reads a file's information.
+
+        Args:
+            href (str): The file's href, to be read by fsspec.
+
+        Returns:
+            FileInfo: The file's information, including checksum and size.
+
+        """
+        m = hashlib.sha256()
+        with fsspec.open(href, mode="rb") as file:
+            data = file.read()
+            size = len(data)
+            m.update(data)
+        hash = multihash.encode(m.digest(), code="sha2-256", length=m.digest_size)
+        checksum = cast(str, multihash.to_hex_string(hash))
+        return FileInfo(checksum=checksum, size=size)
+
+
+class Builder:
+    """Builds a STAC item from assets."""
+
+    antimeridian_strategy: Strategy
+    """The strategy used to fix geometries that cross the the antimeridian."""
+
+    _assets: Dict[str, Asset]
+
+    def __init__(
+        self,
+        *,
+        antimeridian_strategy: Strategy = DEFAULT_ANTIMERIDIAN_STRATEGY,
+    ) -> None:
+        """Creates a new builder with no assets.
+
+        Args:
+            antimeridian_strategy (optional, Strategy): The strategy to use to
+                fix polygons that cross the antimeridian.
+        """
+        self.antimeridian_strategy = antimeridian_strategy
+        self._assets = {}
+
+    def get_asset(self, key: str) -> Optional[Asset]:
+        """Gets an asset by key.
+
+        Args:
+            key (str): The asset key.
+
+        Returns:
+            Optional[Asset]: The asset at the provided key, or None.
+        """
+        return self._assets.get(key)
+
+    def add_asset(
+        self,
+        key: str,
+        asset: Asset,
+    ) -> Optional[Asset]:
+        """Adds an asset to this builder.
+
+        Returns the old asset if this key already existed.
+
+        Args:
+            key (str): The asset key.
+            asset (Asset): The asset.
+
+        Returns:
+            Optional[Asset]: The asset that was replaced.
+        """
+        old_asset = self._assets.pop(key, None)
+        self._assets[key] = asset
+        return old_asset
+
+    def add_assets(self, assets: Dict[str, Asset]) -> Dict[str, Asset]:
+        """Adds assets to this builder.
+
+        Returns any old assets that were removed from the builder.
+
+        Args:
+            assets (Dict[str, Asset]): The assets to add.
+
+        Returns:
+            Dict[str, Asset]: Any assets that were replaced.
+        """
+        old_assets = dict()
+        for key, asset in assets.items():
+            old_asset = self.add_asset(key, asset)
+            if old_asset:
+                old_assets[key] = old_asset
+        return old_assets
+
+    def remove_asset(self, key: str) -> Optional[Asset]:
+        """Removes and returns an asset.
+
+        Args:
+            key (str): The asset key.
+
+        Returns:
+            Optional[Asset]: The removed asset, or None if none was removed.
+        """
+        return self._assets.pop(key, None)
+
+    def create_item(self, id: Optional[str] = None) -> Item:
+        """Creates a pystac Item using this builder's assets.
+
+        Args:
+            id (optional, str): The id of the created item. If not provided, the
+                builder will use its `id()` method.
+
+        Returns:
+            Item: The Item created by this builder.
+        """
+        item_info = self.item_info(id)
+        if item_info.geometry:
+            bbox = self.bbox(item_info.geometry)
+        else:
+            bbox = None
+        item = Item(
+            id=item_info.id,
+            geometry=item_info.geometry,
+            bbox=bbox,
+            datetime=item_info.datetime,
+            properties=item_info.properties,
+        )
+        stactools.core.utils.antimeridian.fix_item(item, self.antimeridian_strategy)
+        if item_info.projection:
+            projection = ProjectionExtension.ext(item, add_if_missing=True)
+            projection.apply(**item_info.projection)
+        if item_info.eo:
+            eo = EOExtension.ext(item, add_if_missing=True)
+            eo.apply(**item_info.eo)
+
+        for key, asset in self._assets.items():
+            item.add_asset(key, asset)
+            asset_info = item_info.asset_infos.get(key)
+            if not asset_info:
+                continue
+            if asset_info.projection:
+                asset_projection = AssetProjectionExtension.ext(
+                    asset, add_if_missing=True
+                )
+                asset_projection.apply(**asset_info.projection)
+            if asset_info.raster:
+                raster = RasterExtension.ext(asset, add_if_missing=True)
+                raster.apply(**asset_info.raster)
+            if asset_info.eo:
+                asset_eo = AssetEOExtension.ext(asset, add_if_missing=True)
+                asset_eo.apply(**asset_info.eo)
+            if asset_info.classification:
+                if CLASSIFICATION_EXTENSION_HREF not in item.stac_extensions:
+                    item.stac_extensions.append(CLASSIFICATION_EXTENSION_HREF)
+                asset.extra_fields.update(**asset_info.classification)
+            if asset_info.calculate_file_info:
+                file = FileExtension.ext(asset, add_if_missing=True)
+                file_info = FileInfo.read(asset.href)
+                file.checksum = file_info.checksum
+                file.size = file_info.size
+            asset.extra_fields.update(asset_info.extra_fields)
+
+        return item
+
+    def item_info(self, id: Optional[str]) -> ItemInfo:
+        """Returns the ItemInfo object for this builder.
+
+        ItemInfo contains optional fields that will be included in the final
+        item, and AssetInfo objects that will be added to this builder's assets.
+        This method includes logic to consolidate identical projection
+        information from AssetInfo objects up to the ItemInfo.
+
+        Args:
+            id (optional, str): The id of the created item. If not provided,
+                will use the `id()` method of this builder.
+
+        Returns:
+            ItemInfo: The item's information, e.g. its geometry and asset information.
+        """
+        asset_infos = dict()
+        projections = []
+        geometries = []
+        for key in self._assets:
+            asset_info = self.asset_info(key)
+            if asset_info is None:
+                continue
+            if asset_info.projection:
+                projections.append(asset_info.projection)
+            if asset_info.geometry:
+                geometries.append(asset_info.geometry)
+            asset_infos[key] = asset_info
+
+        if projections and all(
+            projection == projections[0] for projection in projections
+        ):
+            projection = projections[0]
+            for key in asset_infos:
+                asset_infos[key].projection = None
+        else:
+            projection = None
+
+        geometry = self.geometry(geometries)
+
+        return ItemInfo(
+            id=id or self.id(asset_infos),
+            datetime=self.datetime(asset_infos),
+            geometry=geometry,
+            properties=self.properties(asset_infos),
+            projection=projection,
+            asset_infos=asset_infos,
+            eo=None,
+        )
+
+    def id(self, asset_infos: Dict[str, AssetInfo]) -> str:
+        """Returns the id for this item, possibly derived from asset information.
+
+        Args:
+            asset_infos (Dict[str, AssetInfo]): AssetInfos, possibly produced by reading assets.
+
+        Raises:
+            NotImplementedError: By default, raises a not implemented error.
+
+        Returns:
+            str: The item id.
+        """
+        raise NotImplementedError
+
+    def datetime(
+        self, asset_infos: Dict[str, AssetInfo]
+    ) -> Optional[datetime.datetime]:
+        """Returns the datetime for this item, possibly derived from asset information.
+
+        Args:
+            asset_infos (Dict[str, AssetInfo]): AssetInfos, possibly produced by reading assets.
+
+        Raises:
+            NotImplementedError: By default, raises a not implemented error.
+
+        Returns:
+            Optional[datetime.datetime]: Returns this item's datetime.
+        """
+        raise NotImplementedError
+
+    def properties(self, asset_infos: Dict[str, AssetInfo]) -> Object:
+        """Returns this item's extra properties.
+
+        Args:
+            asset_infos (Dict[str, AssetInfo]): Asset information, possibly read from the assets.
+
+        Returns:
+            Object: The item's properties, by default an empty dictionary.
+        """
+        return {}
+
+    def asset_info(self, key: str) -> Optional[AssetInfo]:
+        """Returns the asset information for the provided key.
+
+        By default, returns None, as some assets may not have any extra
+        information. Subclasses should override the method to return rich
+        information about assets.
+
+        Args:
+            key (str): The asset key
+
+        Returns:
+            Optional[AssetInfo]: Either None, or information about the asset.
+        """
+        return None
+
+    def geometry(self, geometries: List[Object]) -> Optional[Object]:
+        """Returns a single geometry from a list of geometries that will be used
+        as the item's geometry.
+
+        By default, will return:
+        - None, if the input list is empty,
+        - The single geometry if all geometries are identical,
+        - Or raise a ValueError if all geometries are not identical.
+
+        Subclasses should override this method if they can provide geometries
+        from other sources, or if they have logic to handle multiple geometries
+        (e.g. enveloping).
+
+        Args:
+            geometries (List[Dict[str, Any]]): The input geometries.
+
+        Raises:
+            ValueError: Raised if the length of the input list is more than one.
+
+        Returns:
+            Optional[Dict[str, Any]]: The item's geometry, or None.
+        """
+        if not geometries:
+            return None
+        elif all(geometry == geometries[0] for geometry in geometries):
+            return geometries[0]
+        else:
+            raise ValueError("Cannot determine a unique geometry for this item")
+
+    def bbox(self, geometry: Object) -> List[float]:
+        """Returns the bounding box for the item's geometry.
+
+        By default, just returns the geometry's bounds, but subclasses could
+        have different behavior.
+
+        Args:
+            geometry (Dict[str, Any]): The item's geometry
+
+        Returns:
+            List[float]: The bounding box.
+        """
+        return list(shapely.geometry.shape(geometry).bounds)
+
+
+class RasterioBuilder(Builder):
+    """Builds an item using rasterio to read information from assets."""
+
+    rasterio_keys: Set[str]
+    read_href_modifier: Optional[ReadHrefModifier]
+
+    def __init__(
+        self,
+        *,
+        read_href_modifier: Optional[ReadHrefModifier] = None,
+        antimeridian_strategy: Strategy = DEFAULT_ANTIMERIDIAN_STRATEGY,
+    ) -> None:
+        """Creates a new rasterio builder with no assets.
+
+        Args:
+            read_href_modifier (optional, ReadHrefModifier): An optional
+                callable that will modify any asset hrefs before reading with
+                rasterio.
+            antimeridian_strategy (optional, Strategy): The strategy that will
+                be used to fix geometries that cross the antimeridian.
+            include_projection_extension (optional, bool): Should the item
+                and/or assets include the projection extension?
+        """
+        super().__init__(
+            antimeridian_strategy=antimeridian_strategy,
+        )
+        self.rasterio_keys = set()
+        self.read_href_modifier = read_href_modifier
+
+    def add_rasterio_asset(
+        self,
+        key: str,
+        asset: Asset,
+    ) -> Optional[Asset]:
+        """Adds an asset that will be read by rasterio to get band and
+        projection information.
+
+
+        See `add_asset` for the description of parameters.
+        """
+        self.rasterio_keys.add(key)
+        return self.add_asset(
+            key,
+            asset,
+        )
+
+    def asset_info(self, key: str) -> Optional[AssetInfo]:
+        """Returns an asset info for assets specified in `self.rasterio_keys`.
+
+        Uses `read_asset_info_with_rasterio` to do the reading.
+        """
+        if key in self.rasterio_keys:
+            asset = self.get_asset(key)
+            assert asset
+            return self.read_asset_info_with_rasterio(asset)
+        else:
+            return None
+
+    def read_asset_info_with_rasterio(self, asset: Asset) -> AssetInfo:
+        """Reads a given asset with rasterio, return the asset's information.
+
+        The asset information will include projection and raster information.
+
+        Args:
+            asset (Asset): The pystac asset to be read.
+
+        Returns:
+            AssetInfo: The asset information.
+        """
+        projection = dict()
+        raster = dict()
+        href = asset.href
+        if self.read_href_modifier:
+            href = self.read_href_modifier(asset.href)
+        with rasterio.open(href) as dataset:
+            crs = dataset.crs
+            projection["bbox"] = dataset.bounds
+            projection["transform"] = list(dataset.transform)[0:6]
+            projection["shape"] = dataset.shape
+            bands = list()
+            for dtype, nodata, scale, offset, units in zip(
+                dataset.dtypes,
+                dataset.nodatavals,
+                dataset.scales,
+                dataset.offsets,
+                dataset.units,
+            ):
+                bands.append(
+                    RasterBand.create(
+                        data_type=dtype,
+                        nodata=nodata,
+                        scale=scale,
+                        offset=offset,
+                        unit=units,
+                    )
+                )
+            raster["bands"] = bands
+        projection["geometry"] = shapely.geometry.mapping(
+            shapely.geometry.box(*projection["bbox"])
+        )
+        try:
+            projection["epsg"] = crs.to_epsg()
+        except CRSError:
+            projection["epsg"] = None
+        if projection["epsg"] is None:
+            projection["wkt2"] = crs.to_wkt("WKT2")
+        if projection["epsg"] == EPSG:
+            geometry = projection["geometry"]
+        else:
+            geometry = stactools.core.projection.reproject_geom(
+                crs, f"EPSG:{EPSG}", projection["geometry"], precision=6
+            )
+        del projection["bbox"]
+        return AssetInfo(
+            geometry=geometry,
+            projection=projection,
+            raster=raster,
+            eo=None,
+            classification=None,
+            calculate_file_info=False,
+            extra_fields={},
+        )
+
+
+class SingleFileRasterioBuilder(RasterioBuilder):
+    """Creates an item from a single file."""
+
+    DEFAULT_KEY = "data"
+    """The default key that will point to the single file."""
+
+    _key: str
+
+    def __init__(
+        self,
+        key: str,
+        asset: Asset,
+    ):
+        """Creates a new builder with the given asset and asset key."""
+        super().__init__()
+        self._key = key
+        self.add_rasterio_asset(
+            key,
+            asset,
+        )
+
+    @classmethod
+    def from_href(
+        cls, href: str, key: str = DEFAULT_KEY
+    ) -> "SingleFileRasterioBuilder":
+        """Creates a builder from a single href."""
+        return cls(key, Asset(href, roles=["data"]))
+
+    @property
+    def asset(self) -> Asset:
+        """Returns the asset for the single file.
+
+        Returns:
+            Asset: The single file asset.
+        """
+        return self._assets[self._key]
+
+    def id(self, asset_infos: Dict[str, AssetInfo]) -> str:
+        """Sets the id to the basename (w/o extension) of the single file.
+
+        Args:
+            assets (Assets): The assets for this builder (unused).
+
+        Returns:
+            str: The id for the item.
+        """
+        return os.path.splitext(os.path.basename(self.asset.href))[0]
+
+
+class SingleCOGBuilder(SingleFileRasterioBuilder):
+    """Creates an item from a single COG file."""
+
+    @classmethod
+    def from_href(
+        cls,
+        href: str,
+        key: str = SingleFileRasterioBuilder.DEFAULT_KEY,
+    ) -> "SingleCOGBuilder":
+        return cls(
+            key,
+            Asset(href, roles=["data"], media_type=MediaType.COG),
+        )

--- a/src/stactools/modis/__init__.py
+++ b/src/stactools/modis/__init__.py
@@ -1,6 +1,7 @@
 import stactools.core
 from stactools.cli.registry import Registry
 
+from stactools.modis.cog import cogify
 from stactools.modis.stac import create_item
 
 stactools.core.use_fsspec()
@@ -15,4 +16,4 @@ def register_plugin(registry: Registry) -> None:
 __version__ = "0.2.0"
 """Library version"""
 
-__all__ = ["create_item"]
+__all__ = ["create_item", "cogify"]

--- a/src/stactools/modis/builder.py
+++ b/src/stactools/modis/builder.py
@@ -1,0 +1,253 @@
+import datetime
+import os
+from typing import Dict, List, Optional, cast
+
+import pystac.utils
+from pystac import Asset, Item, MediaType
+from pystac.extensions.eo import Band
+from pystac.extensions.raster import RasterBand
+from stactools.core.io import ReadHrefModifier
+from stactools.core.utils.antimeridian import Strategy
+
+import stactools.modis
+from stactools.builder import AssetInfo, ItemInfo, Object, RasterioBuilder
+from stactools.modis.fragments import Fragments
+from stactools.modis.metadata import Metadata
+
+HDF_ASSET_KEY = "hdf"
+HDF_ASSET_TITLE = "Source data containing all bands"
+XML_ASSET_KEY = "metadata"
+XML_ASSET_TITLE = "Federal Geographic Data Committee (FGDC) Metadata"
+
+
+class ModisBuilder(RasterioBuilder):
+
+    metadata: Optional[Metadata]
+    """The data read from an XML metadata file."""
+
+    def __init__(
+        self,
+        read_href_modifier: Optional[ReadHrefModifier] = None,
+        antimeridian_strategy: Strategy = Strategy.SPLIT,
+    ):
+        """Creates a new modis builder."""
+        super().__init__(
+            read_href_modifier=read_href_modifier,
+            antimeridian_strategy=antimeridian_strategy,
+        )
+        self.metadata = None
+
+    def add_hdf_or_xml_href(
+        self, href: str, cog_directory: Optional[str] = None, create_cogs: bool = False
+    ) -> None:
+        """Adds two assets, the XML metadata file and HDF data file.
+
+        Either href can be provided.
+
+        Args:
+            href (str): The XML or HDF href.
+            cog_directory (optional, str): The optional directory that does (or will) hold the COGs.
+            create_cogs (optional, str): Should COGs be created from the HDF file?
+        """
+        basename, ext = os.path.splitext(href)
+        if ext == ".xml":
+            hdf_href = basename
+            if os.path.splitext(hdf_href)[1] != ".hdf":
+                raise ValueError(f"HREF does not end in .hdf.xml as expected: {href}")
+            xml_href = href
+        elif ext == ".hdf":
+            hdf_href = href
+            xml_href = f"{href}.xml"
+        else:
+            raise ValueError(f"Invalid HDF or XML href: {href}")
+        self.add_xml_asset(xml_href)
+        self.add_hdf_asset(
+            hdf_href, cog_directory=cog_directory, create_cogs=create_cogs
+        )
+
+    def add_hdf_asset(
+        self, href: str, cog_directory: Optional[str] = None, create_cogs: bool = False
+    ) -> None:
+        """Adds an HDF asset by href.
+
+        The asset key is defined by HDF_ASSET_KEY.
+
+        Args:
+            href (str): The HDF href.
+            cog_directory (optional, str): The optional directory that does (or will) hold the COGs.
+            create_cogs (optional, str): Should COGs be created from the HDF file?
+        """
+        assert os.path.splitext(href)[1] == ".hdf"
+        asset = Asset(
+            href=href,
+            media_type=MediaType.HDF,
+            roles=["data"],
+            title=HDF_ASSET_TITLE,
+        )
+        self.add_asset(HDF_ASSET_KEY, asset)
+
+        if create_cogs:
+            if not os.path.exists(asset.href):
+                raise ValueError(
+                    f"Cannot create COGs without a local HDF asset: {asset.href}"
+                )
+            if not cog_directory:
+                cog_directory = os.getcwd()
+            paths, names = stactools.modis.cogify(asset.href, cog_directory)
+        elif cog_directory:
+            id = self.id({})
+            paths = []
+            for file_name in os.listdir(cog_directory):
+                basename, ext = os.path.splitext(file_name)
+                if basename.startswith(id) and ext == ".tif":
+                    paths.append(os.path.join(cog_directory, file_name))
+            if not paths:
+                return
+            names = [
+                "_".join(os.path.basename(path).split(".")[-2].split("_")[1:])
+                for path in paths
+            ]
+        else:
+            return
+
+        bands = self.bands()
+        for path, name in zip(paths, names):
+            band = bands[name]
+            roles = ["data"]
+            extra_roles = band.get("roles")
+            if extra_roles:
+                roles.extend(extra_roles)
+
+            self.add_rasterio_asset(
+                name,
+                Asset(
+                    href=path,
+                    title=band.get("title"),
+                    description=band.get("description"),
+                    media_type=MediaType.COG,
+                    roles=roles,
+                ),
+            )
+
+    def add_xml_asset(self, href: str) -> None:
+        """Adds an XML asset by href.
+
+        The asset key is defined by XML_ASSET_KEY.
+
+        Args:
+            href (str): The XML href.
+        """
+        assert os.path.splitext(href)[1] == ".xml"
+        asset = Asset(
+            href=href,
+            media_type=MediaType.XML,
+            roles=["metadata"],
+            title=XML_ASSET_TITLE,
+        )
+        self.add_asset(XML_ASSET_KEY, asset)
+        self.metadata = Metadata.from_xml_href(href, self.read_href_modifier)
+
+    def create_item(self, id: Optional[str] = None) -> Item:
+        if not self.metadata:
+            raise ValueError(
+                "Cannot create item without metadata -- "
+                "add an XML file or a COG to read the metadata."
+            )
+        return super().create_item(id)
+
+    def item_info(self, id: Optional[str] = None) -> ItemInfo:
+        """Creates a MODIS item."""
+        assert self.metadata
+        item_info = super().item_info(id)
+        if self.metadata.qa_percent_not_produced_cloud:
+            item_info.eo = {"cloud_cover": self.metadata.qa_percent_not_produced_cloud}
+        return item_info
+
+    def asset_info(self, key: str) -> Optional[AssetInfo]:
+        assert self.metadata
+        asset_info = super().asset_info(key)
+        if asset_info is None:
+            return None
+
+        if self.metadata and self.metadata.qa_percent_cloud_cover:
+            asset_info.eo = {"cloud_cover": self.metadata.qa_percent_cloud_cover[key]}
+
+        band = self.bands().get(key)
+        if band is None:
+            return None
+
+        raster_bands = band.get("raster:bands")
+        if raster_bands:
+            asset_info.raster = {
+                "bands": [RasterBand.create(**band) for band in raster_bands]
+            }
+
+        eo_bands = band.get("eo:bands")
+        if eo_bands:
+            asset_info.eo = {"bands": [Band.create(**band) for band in eo_bands]}
+
+        classification_classes = band.get("classification:classes")
+        if classification_classes:
+            asset_info.classification = {
+                "classification:classes": classification_classes
+            }
+
+        return asset_info
+
+    def id(self, asset_infos: Dict[str, AssetInfo]) -> str:
+        """Returns the id as determined from the metadata asset."""
+        assert self.metadata
+        return self.metadata.id
+
+    def datetime(
+        self, asset_infos: Dict[str, AssetInfo]
+    ) -> Optional[datetime.datetime]:
+        """Returns the datetime as determined from the metadata file."""
+        assert self.metadata
+        return self.metadata.datetime
+
+    def properties(self, asset_infos: Dict[str, AssetInfo]) -> Object:
+        """Returns extra properties for the item, as set from fragments."""
+        assert self.metadata
+        fragments = self.fragments()
+        properties = fragments.item()
+        properties["start_datetime"] = pystac.utils.datetime_to_str(
+            self.metadata.start_datetime
+        )
+        properties["end_datetime"] = pystac.utils.datetime_to_str(
+            self.metadata.end_datetime
+        )
+        properties["instruments"] = self.metadata.instruments
+        # Per the discussion in
+        # https://github.com/radiantearth/stac-spec/issues/216, it seems like
+        # the recommendation for multi-platform datasets is to just include both
+        # and use a string separator.
+        properties["platform"] = ",".join(self.metadata.platforms)
+        properties["created"] = pystac.utils.datetime_to_str(self.metadata.created)
+        properties["updated"] = pystac.utils.datetime_to_str(self.metadata.updated)
+        properties["modis:horizontal-tile"] = self.metadata.horizontal_tile
+        properties["modis:vertical-tile"] = self.metadata.vertical_tile
+        properties["modis:tile-id"] = self.metadata.tile_id
+        return cast(Object, properties)
+
+    def geometry(self, geometries: List[Object]) -> Optional[Object]:
+        assert self.metadata
+        return self.metadata.geometry
+
+    def bbox(self, geometry: Object) -> List[float]:
+        assert self.metadata
+        return self.metadata.bbox
+
+    def fragments(self) -> Fragments:
+        return Fragments(self.collection(), self.version())
+
+    def bands(self) -> Object:
+        return cast(Object, self.fragments().bands())
+
+    def collection(self) -> str:
+        assert self.metadata
+        return self.metadata.collection
+
+    def version(self) -> str:
+        assert self.metadata
+        return self.metadata.version

--- a/src/stactools/modis/cog.py
+++ b/src/stactools/modis/cog.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from typing import List, Optional, Tuple
 
 import stactools.core.utils.convert
@@ -28,6 +29,11 @@ def add_cogs(
     Returns:
         List[str]: The COG hrefs
     """
+    warnings.warn(
+        "stactools.modis.cog.add_cogs will be removed in v0.4.0, "
+        "use stactools.modis.cogify and stactools.modis.Builder instead",
+        DeprecationWarning,
+    )
     file = File.from_item(item)
     if create:
         (paths, subdataset_names) = cogify(file.hdf_href, directory)
@@ -65,6 +71,11 @@ def add_cog_assets(
         List[str]: The list of subdataset names, in case they were intuited from
             the hrefs.
     """
+    warnings.warn(
+        "stactools.modis.cog.add_cogs_assets will be removed in v0.4.0, "
+        "use stactools.modis.cogify and stactools.modis.Builder instead",
+        DeprecationWarning,
+    )
     if not subdataset_names:
         subdataset_names = [
             "_".join(os.path.basename(href).split(".")[-2].split("_")[1:])

--- a/src/stactools/modis/file.py
+++ b/src/stactools/modis/file.py
@@ -1,4 +1,5 @@
 import os.path
+import warnings
 
 import pystac.utils
 from pystac import Item
@@ -6,6 +7,11 @@ from pystac import Item
 from stactools.modis.constants import HDF_ASSET_KEY
 from stactools.modis.fragments import Fragments
 from stactools.modis.product import Product
+
+warnings.warn(
+    "stactools.modis.file is deprecated and will be removed in v0.4.0",
+    DeprecationWarning,
+)
 
 
 class File:

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -212,3 +212,7 @@ class Metadata:
             return self.start_datetime + (self.end_datetime - self.start_datetime) / 2
         else:
             return None
+
+    @property
+    def collection(self) -> str:
+        return self.product[3:]

--- a/src/stactools/modis/stac.py
+++ b/src/stactools/modis/stac.py
@@ -1,25 +1,17 @@
 import logging
-import os.path
-import urllib.parse
 from typing import Optional
 
 import pystac
 import pystac.utils
-import rasterio
-import shapely.geometry
-import stactools.core.utils
-import stactools.core.utils.antimeridian
-from pystac import Asset, Collection, Item, MediaType, Summaries
+from pystac import Collection, Item, MediaType, Summaries
 from pystac.extensions.eo import EOExtension
 from pystac.extensions.item_assets import AssetDefinition, ItemAssetsExtension
-from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.raster import RasterExtension
 from pystac.extensions.scientific import ScientificExtension
 from stactools.core.io import ReadHrefModifier
 from stactools.core.utils.antimeridian import Strategy
 
-import stactools.modis.cog
-import stactools.modis.utils
+from stactools.modis.builder import ModisBuilder
 from stactools.modis.constants import (
     CLASSIFICATION_EXTENSION_HREF,
     HDF_ASSET_KEY,
@@ -27,10 +19,7 @@ from stactools.modis.constants import (
     METADATA_ASSET_KEY,
     METADATA_ASSET_PROPERTIES,
 )
-from stactools.modis.file import File
-from stactools.modis.metadata import Metadata
 from stactools.modis.product import Product
-from stactools.modis.warnings import MissingProj
 
 logger = logging.getLogger(__name__)
 
@@ -123,84 +112,14 @@ def create_item(
     Returns:
         pystac.Item: A STAC Item representing this MODIS image.
     """
-    file = File(href)
-    metadata = Metadata.from_xml_href(file.xml_href, read_href_modifier)
-    fragments = file.product.fragments(metadata.version)
-    properties = fragments.item()
-    properties["start_datetime"] = pystac.utils.datetime_to_str(metadata.start_datetime)
-    properties["end_datetime"] = pystac.utils.datetime_to_str(metadata.end_datetime)
-    properties["modis:horizontal-tile"] = metadata.horizontal_tile
-    properties["modis:vertical-tile"] = metadata.vertical_tile
-    properties["modis:tile-id"] = metadata.tile_id
-    item = pystac.Item(
-        id=metadata.id,
-        geometry=metadata.geometry,
-        bbox=metadata.bbox,
-        datetime=metadata.datetime,
-        properties=properties,
+    builder = ModisBuilder(
+        antimeridian_strategy=antimeridian_strategy,
+        read_href_modifier=read_href_modifier,
     )
-    stactools.core.utils.antimeridian.fix_item(item, antimeridian_strategy)
-
-    item.common_metadata.instruments = metadata.instruments
-    # Per the discussion in
-    # https://github.com/radiantearth/stac-spec/issues/216, it seems like
-    # the recommendation for multi-platform datasets is to just include both
-    # and use a string separator.
-    item.common_metadata.platform = ",".join(metadata.platforms)
-    item.common_metadata.created = metadata.created
-    item.common_metadata.updated = metadata.updated
-
-    if metadata.qa_percent_not_produced_cloud:
-        eo = EOExtension.ext(item, add_if_missing=True)
-        eo.cloud_cover = metadata.qa_percent_not_produced_cloud
-
-    properties = HDF_ASSET_PROPERTIES.copy()
-    properties["href"] = file.hdf_href
-    item.add_asset(HDF_ASSET_KEY, Asset.from_dict(properties))
-
-    properties = METADATA_ASSET_PROPERTIES.copy()
-    properties["href"] = file.xml_href
-    item.add_asset(METADATA_ASSET_KEY, Asset.from_dict(properties))
-
-    url = urllib.parse.urlparse(file.hdf_href)
-    is_local_hdf = not url.scheme and os.path.isfile(file.hdf_href)
-
-    if is_local_hdf:
-        subdatasets = stactools.modis.utils.subdatasets(file.hdf_href)
-        if not subdatasets:
-            raise ValueError(f"No subdatasets found in HDF file: {file.hdf_href}")
-        with rasterio.open(subdatasets[0]) as dataset:
-            crs = dataset.crs
-            proj_bbox = dataset.bounds
-            proj_transform = list(dataset.transform)[0:6]
-            proj_shape = dataset.shape
-        proj_geometry = shapely.geometry.mapping(shapely.geometry.box(*proj_bbox))
-        projection = ProjectionExtension.ext(item, add_if_missing=True)
-        projection.epsg = None
-        projection.wkt2 = crs.to_wkt("WKT2")
-        projection.geometry = proj_geometry
-        projection.transform = proj_transform
-        projection.shape = proj_shape
-    else:
-        logger.warning(MissingProj(item, file))
-
-    if create_cogs:
-        if not is_local_hdf:
-            raise ValueError(
-                f"Cannot cogify remote or non-existent HDF files: {file.hdf_href}"
-            )
-        elif not cog_directory:
-            cog_directory = os.path.dirname(file.hdf_href)
-
-    if cog_directory:
-        stactools.modis.cog.add_cogs(item, cog_directory, create_cogs)
-        if metadata.qa_percent_cloud_cover:
-            EOExtension.add_to(item)
-        for name, cloud_cover in metadata.qa_percent_cloud_cover.items():
-            asset = item.assets[name]
-            asset.extra_fields["eo:cloud_cover"] = cloud_cover
-
-    return item
+    builder.add_hdf_or_xml_href(
+        href, cog_directory=cog_directory, create_cogs=create_cogs
+    )
+    return builder.create_item()
 
 
 def collection_id(product: str, version: str) -> str:

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006.2018142182903/MCD12Q1.A2001001.h00v08.006.2018142182903.json
@@ -119,15 +119,15 @@
     "LW_Class_2": "f9ffa4, Land",
     "start_datetime": "2001-01-01T00:00:00Z",
     "end_datetime": "2001-12-31T23:59:59Z",
-    "modis:horizontal-tile": 0,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51000008",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2018-05-22T18:29:03Z",
     "updated": "2019-08-26T14:27:11.357000Z",
+    "modis:horizontal-tile": 0,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51000008",
     "datetime": null
   },
   "geometry": {
@@ -204,20 +204,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MCD12Q1.A2001001.h00v08.006.2018142182903.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MCD12Q1.A2001001.h00v08.006.2018142182903.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MCD15A2H/061/MCD15A2H.A2022025.h01v11.061.2022035062702/MCD15A2H.A2022025.h01v11.061.2022035062702.json
+++ b/tests/data-files/expected/MCD15A2H/061/MCD15A2H.A2022025.h01v11.061.2022035062702/MCD15A2H.A2022025.h01v11.061.2022035062702.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 1,
-    "modis:vertical-tile": 11,
-    "modis:tile-id": "51001011",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-04T06:27:02Z",
     "updated": "2022-02-04T00:36:19.295000Z",
+    "modis:horizontal-tile": 1,
+    "modis:vertical-tile": 11,
+    "modis:tile-id": "51001011",
     "datetime": null
   },
   "geometry": {
@@ -90,20 +90,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MCD15A2H.A2022025.h01v11.061.2022035062702.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MCD15A2H.A2022025.h01v11.061.2022035062702.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MCD15A2H.A2022025.h01v11.061.2022035062702.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MCD15A3H/061/MCD15A3H.A2022033.h12v10.061.2022039062215/MCD15A3H.A2022033.h12v10.061.2022039062215.json
+++ b/tests/data-files/expected/MCD15A3H/061/MCD15A3H.A2022033.h12v10.061.2022039062215/MCD15A3H.A2022033.h12v10.061.2022039062215.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-05T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51012010",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-08T06:22:15Z",
     "updated": "2022-02-08T00:30:21.656000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51012010",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MCD15A3H.A2022033.h12v10.061.2022039062215.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MCD15A3H.A2022033.h12v10.061.2022039062215.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MCD15A3H.A2022033.h12v10.061.2022039062215.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
+++ b/tests/data-files/expected/MCD43A4/006/MCD43A4.A2022019.h10v04.006.2022028111747/MCD43A4.A2022019.h10v04.006.2022028111747.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-11T00:00:00Z",
     "end_datetime": "2022-01-26T23:59:59.999999Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51010004",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-01-28T11:20:24Z",
     "updated": "2022-01-28T05:33:06.715000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51010004",
     "eo:cloud_cover": 34,
     "datetime": "2022-01-19T00:00:00Z"
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MCD43A4.A2022019.h10v04.006.2022028111747.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MCD43A4.A2022019.h10v04.006.2022028111747.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MCD43A4/061/MCD43A4.A2022032.h14v10.061.2022041051831/MCD43A4.A2022032.h14v10.061.2022041051831.json
+++ b/tests/data-files/expected/MCD43A4/061/MCD43A4.A2022032.h14v10.061.2022041051831/MCD43A4.A2022032.h14v10.061.2022041051831.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-24T00:00:00Z",
     "end_datetime": "2022-02-08T23:59:59.999999Z",
-    "modis:horizontal-tile": 14,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51014010",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-10T05:19:45Z",
     "updated": "2022-02-09T23:25:46.095000Z",
+    "modis:horizontal-tile": 14,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51014010",
     "eo:cloud_cover": 10,
     "datetime": "2022-02-01T00:00:00Z"
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MCD43A4.A2022032.h14v10.061.2022041051831.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MCD43A4.A2022032.h14v10.061.2022041051831.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MCD43A4.A2022032.h14v10.061.2022041051831.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MCD64A1/061/MCD64A1.A2021335.h10v06.061.2022035055453/MCD64A1.A2021335.h10v06.061.2022035055453.json
+++ b/tests/data-files/expected/MCD64A1/061/MCD64A1.A2021335.h10v06.061.2022035055453/MCD64A1.A2021335.h10v06.061.2022035055453.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-12-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51010006",
     "instruments": [
       "modis"
     ],
     "platform": "terra,aqua",
     "created": "2022-02-04T10:54:53Z",
     "updated": "2022-02-04T04:59:11.327000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51010006",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MCD64A1.A2021335.h10v06.061.2022035055453.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MCD64A1.A2021335.h10v06.061.2022035055453.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MCD64A1.A2021335.h10v06.061.2022035055453.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD09A1/061/MOD09A1.A2022033.h19v10.061.2022042043514/MOD09A1.A2022033.h19v10.061.2022042043514.json
+++ b/tests/data-files/expected/MOD09A1/061/MOD09A1.A2022033.h19v10.061.2022042043514/MOD09A1.A2022033.h19v10.061.2022042043514.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 19,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51019010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:35:14Z",
     "updated": "2022-02-10T22:44:13.607000Z",
+    "modis:horizontal-tile": 19,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51019010",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD09A1.A2022033.h19v10.061.2022042043514.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD09A1.A2022033.h19v10.061.2022042043514.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD09A1.A2022033.h19v10.061.2022042043514.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD09Q1/061/MOD09Q1.A2022033.h10v10.061.2022042044048/MOD09Q1.A2022033.h10v10.061.2022042044048.json
+++ b/tests/data-files/expected/MOD09Q1/061/MOD09Q1.A2022033.h10v10.061.2022042044048/MOD09Q1.A2022033.h10v10.061.2022042044048.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51010010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:40:48Z",
     "updated": "2022-02-10T22:51:55.839000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51010010",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD09Q1.A2022033.h10v10.061.2022042044048.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD09Q1.A2022033.h10v10.061.2022042044048.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD09Q1.A2022033.h10v10.061.2022042044048.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006.2022031045818/MOD10A1.A2022029.h10v05.006.2022031045818.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-29T00:00:00Z",
     "end_datetime": "2022-01-29T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-31T04:58:23Z",
     "updated": "2022-01-30T22:03:40.097000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD10A1.A2022029.h10v05.006.2022031045818.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD10A1.A2022029.h10v05.006.2022031045818.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD10A1/061/MOD10A1.A2022040.h11v05.061.2022042042026/MOD10A1.A2022040.h11v05.061.2022042042026.json
+++ b/tests/data-files/expected/MOD10A1/061/MOD10A1.A2022040.h11v05.061.2022042042026/MOD10A1.A2022040.h11v05.061.2022042042026.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-09T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51011005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:20:28Z",
     "updated": "2022-02-10T21:25:29.136000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51011005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD10A1.A2022040.h11v05.061.2022042042026.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD10A1.A2022040.h11v05.061.2022042042026.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD10A1.A2022040.h11v05.061.2022042042026.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD10A2/061/MOD10A2.A2022033.h09v05.061.2022042050729/MOD10A2.A2022033.h09v05.061.2022042050729.json
+++ b/tests/data-files/expected/MOD10A2/061/MOD10A2.A2022033.h09v05.061.2022042050729/MOD10A2.A2022033.h09v05.061.2022042050729.json
@@ -5,17 +5,17 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T05:07:40Z",
     "updated": "2022-02-10T22:17:10.512000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -43,6 +43,10 @@
         ]
       ]
     },
+    "proj:shape": [
+      2400,
+      2400
+    ],
     "proj:transform": [
       463.3127165279165,
       0.0,
@@ -50,10 +54,6 @@
       0.0,
       -463.3127165279167,
       4447802.078667
-    ],
-    "proj:shape": [
-      2400,
-      2400
     ],
     "datetime": null
   },
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD10A2.A2022033.h09v05.061.2022042050729.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD10A2.A2022033.h09v05.061.2022042050729.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD10A2.A2022033.h09v05.061.2022042050729.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     },
     "Eight_Day_Snow_Cover": {

--- a/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
+++ b/tests/data-files/expected/MOD11A1/006/MOD11A1.A2022030.h10v05.006.2022031094827/MOD11A1.A2022030.h10v05.006.2022031094827.json
@@ -21,15 +21,15 @@
     "QC_LST_Error_flag_11": "average LST error > 3K",
     "start_datetime": "2022-01-30T00:00:00Z",
     "end_datetime": "2022-01-30T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-31T09:48:27Z",
     "updated": "2022-01-31T03:53:55.289000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "eo:cloud_cover": 30,
     "datetime": null
   },
@@ -81,20 +81,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD11A1.A2022030.h10v05.006.2022031094827.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD11A1.A2022030.h10v05.006.2022031094827.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD11A1/061/MOD11A1.A2022041.h19v02.061.2022042095544/MOD11A1.A2022041.h19v02.061.2022042095544.json
+++ b/tests/data-files/expected/MOD11A1/061/MOD11A1.A2022041.h19v02.061.2022042095544/MOD11A1.A2022041.h19v02.061.2022042095544.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-10T00:00:00Z",
     "end_datetime": "2022-02-10T23:59:59Z",
-    "modis:horizontal-tile": 19,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51019002",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T09:55:44Z",
     "updated": "2022-02-11T04:04:50.881000Z",
+    "modis:horizontal-tile": 19,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51019002",
     "eo:cloud_cover": 49,
     "datetime": null
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD11A1.A2022041.h19v02.061.2022042095544.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD11A1.A2022041.h19v02.061.2022042095544.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD11A1.A2022041.h19v02.061.2022042095544.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
+++ b/tests/data-files/expected/MOD11A2/006/MOD11A2.A2022017.h10v05.006.2022026205724/MOD11A2.A2022017.h10v05.006.2022026205724.json
@@ -21,15 +21,15 @@
     "QC_LST_Error_flag_11": "average LST error > 3K",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:57:24Z",
     "updated": "2022-01-26T23:32:16.338000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "eo:cloud_cover": 2,
     "datetime": null
   },
@@ -81,20 +81,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD11A2.A2022017.h10v05.006.2022026205724.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD11A2.A2022017.h10v05.006.2022026205724.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD11A2/061/MOD11A2.A2022033.h19v10.061.2022042044121/MOD11A2.A2022033.h19v10.061.2022042044121.json
+++ b/tests/data-files/expected/MOD11A2/061/MOD11A2.A2022033.h19v10.061.2022042044121/MOD11A2.A2022033.h19v10.061.2022042044121.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 19,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51019010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:41:21Z",
     "updated": "2022-02-10T22:57:48.564000Z",
+    "modis:horizontal-tile": 19,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51019010",
     "eo:cloud_cover": 19,
     "datetime": null
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD11A2.A2022033.h19v10.061.2022042044121.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD11A2.A2022033.h19v10.061.2022042044121.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD11A2.A2022033.h19v10.061.2022042044121.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006.2022018175631/MOD13A1.A2022001.h09v05.006.2022018175631.json
@@ -46,15 +46,15 @@
     "Summary_QA_3": "Cloudy - Target not visible, covered with cloud",
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-01-16T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-18T22:56:31Z",
     "updated": "2022-01-18T17:02:41.699000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "datetime": null
   },
   "geometry": {
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD13A1.A2022001.h09v05.006.2022018175631.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD13A1.A2022001.h09v05.006.2022018175631.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD13A1/061/MOD13A1.A2022017.h12v11.061.2022034232214/MOD13A1.A2022017.h12v11.061.2022034232214.json
+++ b/tests/data-files/expected/MOD13A1/061/MOD13A1.A2022017.h12v11.061.2022034232214/MOD13A1.A2022017.h12v11.061.2022034232214.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 11,
-    "modis:tile-id": "51012011",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-04T04:22:14Z",
     "updated": "2022-02-03T22:31:06.875000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 11,
+    "modis:tile-id": "51012011",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD13A1.A2022017.h12v11.061.2022034232214.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD13A1.A2022017.h12v11.061.2022034232214.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD13A1.A2022017.h12v11.061.2022034232214.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006.2022018175746/MOD13Q1.A2022001.h09v05.006.2022018175746.json
@@ -46,15 +46,15 @@
     "Summary_QA_3": "Cloudy - Target not visible, covered with cloud",
     "start_datetime": "2022-01-01T00:00:00Z",
     "end_datetime": "2022-01-16T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-18T22:57:46Z",
     "updated": "2022-01-18T17:05:27.039000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "datetime": null
   },
   "geometry": {
@@ -105,20 +105,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD13Q1.A2022001.h09v05.006.2022018175746.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD13Q1.A2022001.h09v05.006.2022018175746.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD13Q1/061/MOD13Q1.A2022017.h12v11.061.2022034232400/MOD13Q1.A2022017.h12v11.061.2022034232400.json
+++ b/tests/data-files/expected/MOD13Q1/061/MOD13Q1.A2022017.h12v11.061.2022034232400/MOD13Q1.A2022017.h12v11.061.2022034232400.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 11,
-    "modis:tile-id": "51012011",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-04T04:24:00Z",
     "updated": "2022-02-03T22:37:17.991000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 11,
+    "modis:tile-id": "51012011",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD13Q1.A2022017.h12v11.061.2022034232400.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD13Q1.A2022017.h12v11.061.2022034232400.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD13Q1.A2022017.h12v11.061.2022034232400.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A1/006/MOD14A1.A2022017.h10v05.006.2022026155645/MOD14A1.A2022017.h10v05.006.2022026155645.json
@@ -21,15 +21,15 @@
     "QA_bit_2_night_day_1": "Day",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:06.516000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -80,20 +80,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD14A1.A2022017.h10v05.006.2022026155645.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD14A1.A2022017.h10v05.006.2022026155645.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD14A1/061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
+++ b/tests/data-files/expected/MOD14A1/061/MOD14A1.A2022033.h11v05.061.2022041234759/MOD14A1.A2022033.h11v05.061.2022041234759.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51011005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:47:59Z",
     "updated": "2022-02-10T22:59:34.540000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51011005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD14A1.A2022033.h11v05.061.2022041234759.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD14A1.A2022033.h11v05.061.2022041234759.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD14A1.A2022033.h11v05.061.2022041234759.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
+++ b/tests/data-files/expected/MOD14A2/006/MOD14A2.A2022017.h10v05.006.2022026155645/MOD14A2.A2022017.h10v05.006.2022026155645.json
@@ -21,15 +21,15 @@
     "QA_bit_2_night_day_1": "Day",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:56:45Z",
     "updated": "2022-01-26T23:32:05.772000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -80,20 +80,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD14A2.A2022017.h10v05.006.2022026155645.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD14A2.A2022017.h10v05.006.2022026155645.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD14A2/061/MOD14A2.A2022033.h21v05.061.2022041234800/MOD14A2.A2022033.h21v05.061.2022041234800.json
+++ b/tests/data-files/expected/MOD14A2/061/MOD14A2.A2022033.h21v05.061.2022041234800/MOD14A2.A2022033.h21v05.061.2022041234800.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 21,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51021005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:48:00Z",
     "updated": "2022-02-10T23:01:33.748000Z",
+    "modis:horizontal-tile": 21,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51021005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD14A2.A2022033.h21v05.061.2022041234800.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD14A2.A2022033.h21v05.061.2022041234800.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD14A2.A2022033.h21v05.061.2022041234800.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006.2022026205820/MOD15A2H.A2022017.h10v05.006.2022026205820.json
@@ -20,15 +20,15 @@
     "STD_LAI_STD_FPAR_fill_value_class_255": "Fill",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T20:58:20Z",
     "updated": "2022-01-26T23:20:26.941000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -79,20 +79,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD15A2H.A2022017.h10v05.006.2022026205820.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD15A2H.A2022017.h10v05.006.2022026205820.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD15A2H/061/MOD15A2H.A2022033.h13v10.061.2022042045937/MOD15A2H.A2022033.h13v10.061.2022042045937.json
+++ b/tests/data-files/expected/MOD15A2H/061/MOD15A2H.A2022033.h13v10.061.2022042045937/MOD15A2H.A2022033.h13v10.061.2022042045937.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 13,
-    "modis:vertical-tile": 10,
-    "modis:tile-id": "51013010",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T04:59:37Z",
     "updated": "2022-02-10T23:09:54.486000Z",
+    "modis:horizontal-tile": 13,
+    "modis:vertical-tile": 10,
+    "modis:tile-id": "51013010",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD15A2H.A2022033.h13v10.061.2022042045937.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD15A2H.A2022033.h13v10.061.2022042045937.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD15A2H.A2022033.h13v10.061.2022042045937.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006.2022011184136/MOD16A3GF.A2020001.h09v04.006.2022011184136.json
@@ -26,15 +26,15 @@
     "ET_QC_500m_fill_value_class_32767": "Fill",
     "start_datetime": "2020-01-01T00:00:00Z",
     "end_datetime": "2020-12-31T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-11T23:41:47Z",
     "updated": "2022-01-11T17:46:28.061000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -85,20 +85,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD16A3GF.A2020001.h09v04.006.2022011184136.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD16A3GF/061/MOD16A3GF.A2021001.h11v02.061.2022024075208/MOD16A3GF.A2021001.h11v02.061.2022024075208.json
+++ b/tests/data-files/expected/MOD16A3GF/061/MOD16A3GF.A2021001.h11v02.061.2022024075208/MOD16A3GF.A2021001.h11v02.061.2022024075208.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51011002",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-24T12:53:25Z",
     "updated": "2022-01-24T06:56:49.574000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51011002",
     "datetime": null
   },
   "geometry": {
@@ -90,20 +90,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006.2022026222424/MOD17A2H.A2022017.h09v04.006.2022026222424.json
@@ -27,15 +27,15 @@
     "SCF_QC_100": "4, Pixel not produced at all, value coudn't be retrieved(possible reasons: bad L1B data, unusable MOD09GA data)",
     "start_datetime": "2022-01-17T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-26T22:24:24Z",
     "updated": "2022-01-27T01:09:02.847000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -86,20 +86,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD17A2H.A2022017.h09v04.006.2022026222424.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD17A2H.A2022017.h09v04.006.2022026222424.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD17A2H/061/MOD17A2H.A2022025.h08v05.061.2022035065002/MOD17A2H.A2022025.h08v05.061.2022035065002.json
+++ b/tests/data-files/expected/MOD17A2H/061/MOD17A2H.A2022025.h08v05.061.2022035065002/MOD17A2H.A2022025.h08v05.061.2022035065002.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 8,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51008005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-04T06:50:02Z",
     "updated": "2022-02-04T01:03:18.424000Z",
+    "modis:horizontal-tile": 8,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51008005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD17A2H.A2022025.h08v05.061.2022035065002.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD17A2H.A2022025.h08v05.061.2022035065002.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD17A2H.A2022025.h08v05.061.2022035065002.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006.2022031141000/MOD17A2HGF.A2021337.h09v05.006.2022031141000.json
@@ -27,15 +27,15 @@
     "SCF_QC_100": "4, Pixel not produced at all, value coudn't be retrieved (possible reasons: badL1B data, unusable MOD09GA data)",
     "start_datetime": "2021-12-03T00:00:00Z",
     "end_datetime": "2021-12-10T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51009005",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-31T14:10:00Z",
     "updated": "2022-01-31T08:16:07.542000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51009005",
     "datetime": null
   },
   "geometry": {
@@ -86,20 +86,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD17A2HGF.A2021337.h09v05.006.2022031141000.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD17A2HGF/061/MOD17A2HGF.A2021361.h10v06.061.2022020134637/MOD17A2HGF.A2021361.h10v06.061.2022020134637.json
+++ b/tests/data-files/expected/MOD17A2HGF/061/MOD17A2HGF.A2021361.h10v06.061.2022020134637/MOD17A2HGF.A2021361.h10v06.061.2022020134637.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-12-27T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51010006",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-20T13:46:37Z",
     "updated": "2022-01-20T07:50:11.257000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51010006",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006.2021113150137/MOD17A3HGF.A2020001.h09v04.006.2021113150137.json
@@ -19,15 +19,15 @@
     "Npp_500m_fill_value_class_255": "Fill",
     "start_datetime": "2020-01-01T00:00:00Z",
     "end_datetime": "2020-12-31T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2021-04-23T15:01:37Z",
     "updated": "2021-04-23T10:04:29.686000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -78,20 +78,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD17A3HGF.A2020001.h09v04.006.2021113150137.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD17A3HGF/061/MOD17A3HGF.A2021001.h14v02.061.2022020135800/MOD17A3HGF.A2021001.h14v02.061.2022020135800.json
+++ b/tests/data-files/expected/MOD17A3HGF/061/MOD17A3HGF.A2021001.h14v02.061.2022020135800/MOD17A3HGF.A2021001.h14v02.061.2022020135800.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 14,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51014002",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-01-20T13:58:00Z",
     "updated": "2022-01-20T08:00:08.259000Z",
+    "modis:horizontal-tile": 14,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51014002",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
+++ b/tests/data-files/expected/MOD21A2/006/MOD21A2.A2005361.h10v04.006.2018286181506/MOD21A2.A2005361.h10v04.006.2018286181506.json
@@ -37,15 +37,15 @@
     "QC_LST_accuracy_11": "<1 K (Excellent performance)",
     "start_datetime": "2005-12-27T00:00:00Z",
     "end_datetime": "2005-12-31T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51010004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2018-10-13T18:15:06Z",
     "updated": "2018-10-14T20:17:00.495000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51010004",
     "eo:cloud_cover": 40,
     "datetime": null
   },
@@ -97,20 +97,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD21A2.A2005361.h10v04.006.2018286181506.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD21A2.A2005361.h10v04.006.2018286181506.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD21A2/061/MOD21A2.A2022033.h12v08.061.2022042050733/MOD21A2.A2022033.h12v08.061.2022042050733.json
+++ b/tests/data-files/expected/MOD21A2/061/MOD21A2.A2022033.h12v08.061.2022042050733/MOD21A2.A2022033.h12v08.061.2022042050733.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-02T00:00:00Z",
     "end_datetime": "2022-02-09T23:59:59Z",
-    "modis:horizontal-tile": 12,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51012008",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2022-02-11T05:07:33Z",
     "updated": "2022-02-10T23:11:39.276000Z",
+    "modis:horizontal-tile": 12,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51012008",
     "eo:cloud_cover": 36,
     "datetime": null
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD21A2.A2022033.h12v08.061.2022042050733.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD21A2.A2022033.h12v08.061.2022042050733.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD21A2.A2022033.h12v08.061.2022042050733.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006.2021155155636/MOD44B.A2020065.h09v04.006.2021155155636.json
@@ -21,15 +21,15 @@
     "Quality_7_DOY_033_to_045": "0 Clear; 1 Bad",
     "start_datetime": "2020-03-05T00:00:00Z",
     "end_datetime": "2021-03-06T00:00:00Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51009004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2021-06-04T15:56:36Z",
     "updated": "2021-06-04T11:50:13.011000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51009004",
     "datetime": null
   },
   "geometry": {
@@ -80,20 +80,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD44B.A2020065.h09v04.006.2021155155636.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD44B.A2020065.h09v04.006.2021155155636.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD44B.A2020065.h09v04.006.2021155155636.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006.2018033150244/MOD44W.A2015001.h10v04.006.2018033150244.json
@@ -17,15 +17,15 @@
     "QA_10": "Fill - outside of projected area",
     "start_datetime": "2015-01-01T00:00:00Z",
     "end_datetime": "2015-12-31T00:00:00Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51010004",
     "instruments": [
       "modis"
     ],
     "platform": "terra",
     "created": "2018-02-02T15:02:44Z",
     "updated": "2018-04-04T12:07:35.020000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51010004",
     "datetime": null
   },
   "geometry": {
@@ -76,20 +76,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MOD44W.A2015001.h10v04.006.2018033150244.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MOD44W.A2015001.h10v04.006.2018033150244.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MOD44W.A2015001.h10v04.006.2018033150244.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD09A1/061/MYD09A1.A2022025.h09v08.061.2022035070021/MYD09A1.A2022025.h09v08.061.2022035070021.json
+++ b/tests/data-files/expected/MYD09A1/061/MYD09A1.A2022025.h09v08.061.2022035070021/MYD09A1.A2022025.h09v08.061.2022035070021.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51009008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:00:21Z",
     "updated": "2022-02-04T01:11:00.763000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51009008",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD09A1.A2022025.h09v08.061.2022035070021.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD09A1.A2022025.h09v08.061.2022035070021.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD09A1.A2022025.h09v08.061.2022035070021.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD09Q1/061/MYD09Q1.A2022025.h02v08.061.2022035050917/MYD09Q1.A2022025.h02v08.061.2022035050917.json
+++ b/tests/data-files/expected/MYD09Q1/061/MYD09Q1.A2022025.h02v08.061.2022035050917/MYD09Q1.A2022025.h02v08.061.2022035050917.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 2,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51002008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:09:17Z",
     "updated": "2022-02-03T23:16:45.440000Z",
+    "modis:horizontal-tile": 2,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51002008",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD09Q1.A2022025.h02v08.061.2022035050917.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD09Q1.A2022025.h02v08.061.2022035050917.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD09Q1.A2022025.h02v08.061.2022035050917.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD10A1/061/MYD10A1.A2022043.h21v04.061.2022045035657/MYD10A1.A2022043.h21v04.061.2022045035657.json
+++ b/tests/data-files/expected/MYD10A1/061/MYD10A1.A2022043.h21v04.061.2022045035657/MYD10A1.A2022043.h21v04.061.2022045035657.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-12T00:00:00Z",
     "end_datetime": "2022-02-12T23:59:59Z",
-    "modis:horizontal-tile": 21,
-    "modis:vertical-tile": 4,
-    "modis:tile-id": "51021004",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-14T03:57:02Z",
     "updated": "2022-02-13T21:01:32.595000Z",
+    "modis:horizontal-tile": 21,
+    "modis:vertical-tile": 4,
+    "modis:tile-id": "51021004",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD10A1.A2022043.h21v04.061.2022045035657.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD10A1.A2022043.h21v04.061.2022045035657.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD10A1.A2022043.h21v04.061.2022045035657.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD10A2/061/MYD10A2.A2022025.h10v05.061.2022035071201/MYD10A2.A2022025.h10v05.061.2022035071201.json
+++ b/tests/data-files/expected/MYD10A2/061/MYD10A2.A2022025.h10v05.061.2022035071201/MYD10A2.A2022025.h10v05.061.2022035071201.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 5,
-    "modis:tile-id": "51010005",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:12:12Z",
     "updated": "2022-02-04T00:16:00.600000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 5,
+    "modis:tile-id": "51010005",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD10A2.A2022025.h10v05.061.2022035071201.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD10A2.A2022025.h10v05.061.2022035071201.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD10A2.A2022025.h10v05.061.2022035071201.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD11A1/061/MYD11A1.A2022039.h21v07.061.2022040192419/MYD11A1.A2022039.h21v07.061.2022040192419.json
+++ b/tests/data-files/expected/MYD11A1/061/MYD11A1.A2022039.h21v07.061.2022040192419/MYD11A1.A2022039.h21v07.061.2022040192419.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-02-08T00:00:00Z",
     "end_datetime": "2022-02-08T23:59:59Z",
-    "modis:horizontal-tile": 21,
-    "modis:vertical-tile": 7,
-    "modis:tile-id": "51021007",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-09T19:24:19Z",
     "updated": "2022-02-09T13:45:39.603000Z",
+    "modis:horizontal-tile": 21,
+    "modis:vertical-tile": 7,
+    "modis:tile-id": "51021007",
     "eo:cloud_cover": 11,
     "datetime": null
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD11A1.A2022039.h21v07.061.2022040192419.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD11A1.A2022039.h21v07.061.2022040192419.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD11A1.A2022039.h21v07.061.2022040192419.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD11A2/061/MYD11A2.A2022025.h17v00.061.2022035054130/MYD11A2.A2022025.h17v00.061.2022035054130.json
+++ b/tests/data-files/expected/MYD11A2/061/MYD11A2.A2022025.h17v00.061.2022035054130/MYD11A2.A2022025.h17v00.061.2022035054130.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 17,
-    "modis:vertical-tile": 0,
-    "modis:tile-id": "51017000",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:41:30Z",
     "updated": "2022-02-03T23:51:17.900000Z",
+    "modis:horizontal-tile": 17,
+    "modis:vertical-tile": 0,
+    "modis:tile-id": "51017000",
     "eo:cloud_cover": 16,
     "datetime": null
   },
@@ -65,20 +65,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD11A2.A2022025.h17v00.061.2022035054130.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD11A2.A2022025.h17v00.061.2022035054130.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD11A2.A2022025.h17v00.061.2022035054130.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD13A1/061/MYD13A1.A2022009.h25v02.061.2022028071925/MYD13A1.A2022009.h25v02.061.2022028071925.json
+++ b/tests/data-files/expected/MYD13A1/061/MYD13A1.A2022009.h25v02.061.2022028071925/MYD13A1.A2022009.h25v02.061.2022028071925.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-09T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 25,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51025002",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-28T12:19:25Z",
     "updated": "2022-01-28T06:24:44.574000Z",
+    "modis:horizontal-tile": 25,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51025002",
     "datetime": null
   },
   "geometry": {
@@ -90,20 +90,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD13A1.A2022009.h25v02.061.2022028071925.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD13A1.A2022009.h25v02.061.2022028071925.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD13A1.A2022009.h25v02.061.2022028071925.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD13Q1/061/MYD13Q1.A2022009.h09v06.061.2022028072010/MYD13Q1.A2022009.h09v06.061.2022028072010.json
+++ b/tests/data-files/expected/MYD13Q1/061/MYD13Q1.A2022009.h09v06.061.2022028072010/MYD13Q1.A2022009.h09v06.061.2022028072010.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-09T00:00:00Z",
     "end_datetime": "2022-01-24T23:59:59Z",
-    "modis:horizontal-tile": 9,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51009006",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-28T12:20:10Z",
     "updated": "2022-01-28T06:31:42.841000Z",
+    "modis:horizontal-tile": 9,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51009006",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD13Q1.A2022009.h09v06.061.2022028072010.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD13Q1.A2022009.h09v06.061.2022028072010.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD13Q1.A2022009.h09v06.061.2022028072010.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD14A1/061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
+++ b/tests/data-files/expected/MYD14A1/061/MYD14A1.A2022025.h01v07.061.2022035001141/MYD14A1.A2022025.h01v07.061.2022035001141.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 1,
-    "modis:vertical-tile": 7,
-    "modis:tile-id": "51001007",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:11:41Z",
     "updated": "2022-02-03T23:40:07.931000Z",
+    "modis:horizontal-tile": 1,
+    "modis:vertical-tile": 7,
+    "modis:tile-id": "51001007",
     "datetime": null
   },
   "geometry": {
@@ -90,20 +90,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD14A1.A2022025.h01v07.061.2022035001141.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD14A1.A2022025.h01v07.061.2022035001141.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD14A1.A2022025.h01v07.061.2022035001141.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD14A2/061/MYD14A2.A2022025.h03v09.061.2022035001140/MYD14A2.A2022025.h03v09.061.2022035001140.json
+++ b/tests/data-files/expected/MYD14A2/061/MYD14A2.A2022025.h03v09.061.2022035001140/MYD14A2.A2022025.h03v09.061.2022035001140.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 3,
-    "modis:vertical-tile": 9,
-    "modis:tile-id": "51003009",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T05:11:40Z",
     "updated": "2022-02-03T23:23:11.946000Z",
+    "modis:horizontal-tile": 3,
+    "modis:vertical-tile": 9,
+    "modis:tile-id": "51003009",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD14A2.A2022025.h03v09.061.2022035001140.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD14A2.A2022025.h03v09.061.2022035001140.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD14A2.A2022025.h03v09.061.2022035001140.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD15A2H/061/MYD15A2H.A2022025.h22v08.061.2022035072026/MYD15A2H.A2022025.h22v08.061.2022035072026.json
+++ b/tests/data-files/expected/MYD15A2H/061/MYD15A2H.A2022025.h22v08.061.2022035072026/MYD15A2H.A2022025.h22v08.061.2022035072026.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 22,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51022008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:20:26Z",
     "updated": "2022-02-04T01:26:04.137000Z",
+    "modis:horizontal-tile": 22,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51022008",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD15A2H.A2022025.h22v08.061.2022035072026.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD15A2H.A2022025.h22v08.061.2022035072026.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD15A2H.A2022025.h22v08.061.2022035072026.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD16A3GF/061/MYD16A3GF.A2021001.h11v02.061.2022024220526/MYD16A3GF.A2021001.h11v02.061.2022024220526.json
+++ b/tests/data-files/expected/MYD16A3GF/061/MYD16A3GF.A2021001.h11v02.061.2022024220526/MYD16A3GF.A2021001.h11v02.061.2022024220526.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 11,
-    "modis:vertical-tile": 2,
-    "modis:tile-id": "51011002",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-25T03:06:08Z",
     "updated": "2022-01-24T21:08:56.273000Z",
+    "modis:horizontal-tile": 11,
+    "modis:vertical-tile": 2,
+    "modis:tile-id": "51011002",
     "datetime": null
   },
   "geometry": {
@@ -90,20 +90,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD17A2H/061/MYD17A2H.A2022025.h22v08.061.2022035120601/MYD17A2H.A2022025.h22v08.061.2022035120601.json
+++ b/tests/data-files/expected/MYD17A2H/061/MYD17A2H.A2022025.h22v08.061.2022035120601/MYD17A2H.A2022025.h22v08.061.2022035120601.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 22,
-    "modis:vertical-tile": 8,
-    "modis:tile-id": "51022008",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T12:06:01Z",
     "updated": "2022-02-04T06:17:56.444000Z",
+    "modis:horizontal-tile": 22,
+    "modis:vertical-tile": 8,
+    "modis:tile-id": "51022008",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD17A2H.A2022025.h22v08.061.2022035120601.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD17A2H.A2022025.h22v08.061.2022035120601.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD17A2H.A2022025.h22v08.061.2022035120601.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD17A2HGF/061/MYD17A2HGF.A2021361.h13v09.061.2022021010829/MYD17A2HGF.A2021361.h13v09.061.2022021010829.json
+++ b/tests/data-files/expected/MYD17A2HGF/061/MYD17A2HGF.A2021361.h13v09.061.2022021010829/MYD17A2HGF.A2021361.h13v09.061.2022021010829.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-12-27T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 13,
-    "modis:vertical-tile": 9,
-    "modis:tile-id": "51013009",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-21T01:08:29Z",
     "updated": "2022-01-20T19:12:09.442000Z",
+    "modis:horizontal-tile": 13,
+    "modis:vertical-tile": 9,
+    "modis:tile-id": "51013009",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD17A3HGF/061/MYD17A3HGF.A2021001.h13v09.061.2022021012736/MYD17A3HGF.A2021001.h13v09.061.2022021012736.json
+++ b/tests/data-files/expected/MYD17A3HGF/061/MYD17A3HGF.A2021001.h13v09.061.2022021012736/MYD17A3HGF.A2021001.h13v09.061.2022021012736.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2021-01-01T00:00:00Z",
     "end_datetime": "2021-12-31T23:59:59Z",
-    "modis:horizontal-tile": 13,
-    "modis:vertical-tile": 9,
-    "modis:tile-id": "51013009",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-01-21T01:27:36Z",
     "updated": "2022-01-20T19:30:15.987000Z",
+    "modis:horizontal-tile": 13,
+    "modis:vertical-tile": 9,
+    "modis:tile-id": "51013009",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },

--- a/tests/data-files/expected/MYD21A2/061/MYD21A2.A2022025.h10v06.061.2022035072054/MYD21A2.A2022025.h10v06.061.2022035072054.json
+++ b/tests/data-files/expected/MYD21A2/061/MYD21A2.A2022025.h10v06.061.2022035072054/MYD21A2.A2022025.h10v06.061.2022035072054.json
@@ -5,15 +5,15 @@
   "properties": {
     "start_datetime": "2022-01-25T00:00:00Z",
     "end_datetime": "2022-02-01T23:59:59Z",
-    "modis:horizontal-tile": 10,
-    "modis:vertical-tile": 6,
-    "modis:tile-id": "51010006",
     "instruments": [
       "modis"
     ],
     "platform": "aqua",
     "created": "2022-02-04T07:20:54Z",
     "updated": "2022-02-04T01:25:32.670000Z",
+    "modis:horizontal-tile": 10,
+    "modis:vertical-tile": 6,
+    "modis:tile-id": "51010006",
     "datetime": null
   },
   "geometry": {
@@ -64,20 +64,20 @@
     }
   ],
   "assets": {
-    "hdf": {
-      "href": "../../../../MYD21A2.A2022025.h10v06.061.2022035072054.hdf",
-      "type": "application/x-hdf",
-      "title": "Source data containing all bands",
-      "roles": [
-        "data"
-      ]
-    },
     "metadata": {
       "href": "../../../../MYD21A2.A2022025.h10v06.061.2022035072054.hdf.xml",
       "type": "application/xml",
       "title": "Federal Geographic Data Committee (FGDC) Metadata",
       "roles": [
         "metadata"
+      ]
+    },
+    "hdf": {
+      "href": "../../../../MYD21A2.A2022025.h10v06.061.2022035072054.hdf",
+      "type": "application/x-hdf",
+      "title": "Source data containing all bands",
+      "roles": [
+        "data"
       ]
     }
   },


### PR DESCRIPTION
**Related Issue(s):**
- Uses code from stac-utils/stactools#268
- Prerequisite for #70

**Description:**
In an effort to refactor this package to easily extend it to support #70, this PR refactors the item creation code to use a new `Builder` pattern. The builder pattern is defined in a `stactools.builder` namespace, which yanks code from stac-utils/stactools#268. I think this is a good real-world exercise of the builder pattern, with the hopes that lessons learned here can be moved back to stactools.

This is a non-breaking change, there's no real changes to the generated STAC objects (just a couple of trivial re-orderings of the attributes).

I did deprecate two of the COG-creation functions, since they have been superceded by the builder. The deprecation remarks that the functions will be removed in v0.4.0 (two "major" releases from now).

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Example STAC Catalog has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
