### PR TITLE
Release v0.3.0a0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.0a0] - 2022-04-15
 
 ### Added
 
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Initial release.
 
-[Unreleased]: <http://github.com/stactools-packages/modis/compare/v0.2.0..main>
+[Unreleased]: <http://github.com/stactools-packages/modis/compare/v0.3.0a0..main>
+[0.3.0a0]: <http://github.com/stactools-packages/modis/compare/v0.2.0..v0.3.0a0>
 [0.2.0]: <http://github.com/stactools-packages/modis/compare/v0.1.0..v0.2.0>
 [0.1.0]: <https://github.com/stactools-packages/modis/releases/tag/v0.1.0>

--- a/src/stactools/modis/__init__.py
+++ b/src/stactools/modis/__init__.py
@@ -13,7 +13,7 @@ def register_plugin(registry: Registry) -> None:
     registry.register_subcommand(commands.create_modis_command)
 
 
-__version__ = "0.2.0"
+__version__ = "0.3.0a0"
 """Library version"""
 
 __all__ = ["create_item", "cogify"]


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** I think an alpha release so we can take up any changes as we kick the tyres on the COG support. https://test.pypi.org/project/stactools-modis/0.3.0a0/.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

## Release notes

These notes should be included in the annotated tag `v0.3.0a0`:

```
v0.3.0a0

Added:

- Create items from COGs ([#81](https://github.com/stactools-packages/modis/pull/81))
- `s3` extra_requires ([#81](https://github.com/stactools-packages/modis/pull/81))
- The `--s3-requester-pays` pytest option ([#81](https://github.com/stactools-packages/modis/pull/81))

Changed:

- Insert "data" role at the front of the roles list ([#75](https://github.com/stactools-packages/modis/pull/75))
- Keywords ([#77](https://github.com/stactools-packages/modis/pull/77))
- Metadata is now a dataclass ([#80](https://github.com/stactools-packages/modis/pull/80))
- Refactor item creation to use the builder model ([#79](https://github.com/stactools-packages/modis/pull/79))
- `--create-cogs` (instead of `--cogify`) for `stac modis create-catalog` ([#81](https://github.com/stactools-packages/modis/pull/81))
- Method to create expected files for unit tests, it's now `python -m tests.create_expected` ([#81](https://github.com/stactools-packages/modis/pull/81))

Fixed:

- Removed spurious coverage reporting ([#81](https://github.com/stactools-packages/modis/pull/81))
- Asset ordering is now deterministic ([#81](https://github.com/stactools-packages/modis/pull/81))

Removed:

- `file:values` ([#76](https://github.com/stactools-packages/modis/pull/76))
- Some unnecessary custom attributes for some 006 products ([#81](https://github.com/stactools-packages/modis/pull/81))
```