### PR TITLE
Correct missing eo:cloud_cover values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Item IDs no longer contain the production datetime ([#88](https://github.com/stactools-packages/modis/pull/88))
 
+### Fixed
+
+- Added missing `eo:cloud_cover` values to Item properties and Assets ([#91](https://github.com/stactools-packages/modis/pull/91))
+
 ## [0.3.0a0] - 2022-04-15
 
 ### Added

--- a/examples/modis-006/modis-10A1-006/MOD10A1.A2022029.h10v05.006/MOD10A1.A2022029.h10v05.006.json
+++ b/examples/modis-006/modis-10A1-006/MOD10A1.A2022029.h10v05.006/MOD10A1.A2022029.h10v05.006.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51010005",
+    "eo:cloud_cover": 4,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -80.5775666708921,
     40.0637836759185
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A1-006"
 }

--- a/examples/modis-006/modis-11A1-006/MOD11A1.A2022103.h09v05.006.2022104093154/MOD11A1.A2022103.h09v05.006.2022104093154.json
+++ b/examples/modis-006/modis-11A1-006/MOD11A1.A2022103.h09v05.006.2022104093154/MOD11A1.A2022103.h09v05.006.2022104093154.json
@@ -13,7 +13,7 @@
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [

--- a/examples/modis-006/modis-12Q1-006/MCD12Q1.A2001001.h00v08.006/MCD12Q1.A2001001.h00v08.006.json
+++ b/examples/modis-006/modis-12Q1-006/MCD12Q1.A2001001.h00v08.006/MCD12Q1.A2001001.h00v08.006.json
@@ -128,6 +128,7 @@
     "modis:horizontal-tile": 0,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51000008",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -227,6 +228,8 @@
     -169.920147,
     9.998978
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-12Q1-006"
 }

--- a/examples/modis-006/modis-13A1-006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
+++ b/examples/modis-006/modis-13A1-006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "eo:cloud_cover": 5,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13A1-006"
 }

--- a/examples/modis-006/modis-13A1-006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
+++ b/examples/modis-006/modis-13A1-006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
@@ -14,7 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
-    "eo:cloud_cover": 5,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/examples/modis-006/modis-13A1-006/MOD13A1.A2022081.h09v05.006.2022101145817/MOD13A1.A2022081.h09v05.006.2022101145817.json
+++ b/examples/modis-006/modis-13A1-006/MOD13A1.A2022081.h09v05.006.2022101145817/MOD13A1.A2022081.h09v05.006.2022101145817.json
@@ -13,7 +13,7 @@
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [
@@ -53,6 +53,7 @@
       -463.3127165279167,
       3892290.131550028
     ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -127,6 +128,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "modis-13A1-006"

--- a/examples/modis-006/modis-13Q1-006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
+++ b/examples/modis-006/modis-13Q1-006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
@@ -55,7 +55,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
-    "eo:cloud_cover": 5,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/examples/modis-006/modis-13Q1-006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
+++ b/examples/modis-006/modis-13Q1-006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
@@ -55,6 +55,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "eo:cloud_cover": 5,
     "datetime": null
   },
   "geometry": {
@@ -128,6 +129,8 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13Q1-006"
 }

--- a/examples/modis-006/modis-15A2H-006/MOD15A2H.A2022017.h10v05.006/MOD15A2H.A2022017.h10v05.006.json
+++ b/examples/modis-006/modis-15A2H-006/MOD15A2H.A2022017.h10v05.006/MOD15A2H.A2022017.h10v05.006.json
@@ -29,6 +29,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51010005",
+    "eo:cloud_cover": 9,
     "datetime": null
   },
   "geometry": {
@@ -102,6 +103,8 @@
     -80.5775666708921,
     40.0637836759185
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-15A2H-006"
 }

--- a/examples/modis-006/modis-16A3GF-006/MOD16A3GF.A2020001.h09v04.006/MOD16A3GF.A2020001.h09v04.006.json
+++ b/examples/modis-006/modis-16A3GF-006/MOD16A3GF.A2020001.h09v04.006/MOD16A3GF.A2020001.h09v04.006.json
@@ -35,6 +35,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -108,6 +109,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-16A3GF-006"
 }

--- a/examples/modis-006/modis-17A2H-006/MOD17A2H.A2022017.h09v04.006/MOD17A2H.A2022017.h09v04.006.json
+++ b/examples/modis-006/modis-17A2H-006/MOD17A2H.A2022017.h09v04.006/MOD17A2H.A2022017.h09v04.006.json
@@ -36,6 +36,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 70,
     "datetime": null
   },
   "geometry": {
@@ -109,6 +110,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2H-006"
 }

--- a/examples/modis-006/modis-17A2HGF-006/MOD17A2HGF.A2021337.h09v05.006/MOD17A2HGF.A2021337.h09v05.006.json
+++ b/examples/modis-006/modis-17A2HGF-006/MOD17A2HGF.A2021337.h09v05.006/MOD17A2HGF.A2021337.h09v05.006.json
@@ -36,6 +36,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "eo:cloud_cover": 22,
     "datetime": null
   },
   "geometry": {
@@ -109,6 +110,8 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2HGF-006"
 }

--- a/examples/modis-006/modis-17A3HGF-006/MOD17A3HGF.A2020001.h09v04.006/MOD17A3HGF.A2020001.h09v04.006.json
+++ b/examples/modis-006/modis-17A3HGF-006/MOD17A3HGF.A2020001.h09v04.006/MOD17A3HGF.A2020001.h09v04.006.json
@@ -28,6 +28,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 75,
     "datetime": null
   },
   "geometry": {
@@ -101,6 +102,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A3HGF-006"
 }

--- a/examples/modis-006/modis-43A4-006/MCD43A4.A2022073.h28v08.006.2022082044758/MCD43A4.A2022073.h28v08.006.2022082044758.json
+++ b/examples/modis-006/modis-43A4-006/MCD43A4.A2022073.h28v08.006.2022082044758/MCD43A4.A2022073.h28v08.006.2022082044758.json
@@ -13,7 +13,7 @@
     "modis:vertical-tile": 8,
     "modis:tile-id": "51028008",
     "proj:epsg": null,
-    "proj:wkt2": "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not_specified_based_on_custom_spheroid\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
     "proj:geometry": {
       "type": "Polygon",
       "coordinates": [

--- a/examples/modis-006/modis-44B-006/MOD44B.A2020065.h09v04.006/MOD44B.A2020065.h09v04.006.json
+++ b/examples/modis-006/modis-44B-006/MOD44B.A2020065.h09v04.006/MOD44B.A2020065.h09v04.006.json
@@ -30,6 +30,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -103,6 +104,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-44B-006"
 }

--- a/examples/modis-006/modis-44W-006/MOD44W.A2015001.h10v04.006/MOD44W.A2015001.h10v04.006.json
+++ b/examples/modis-006/modis-44W-006/MOD44W.A2015001.h10v04.006/MOD44W.A2015001.h10v04.006.json
@@ -26,6 +26,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51010004",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -99,6 +100,8 @@
     -91.190961,
     50.104685
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-44W-006"
 }

--- a/examples/modis-061/modis-09A1-061/MOD09A1.A2022033.h19v10.061/MOD09A1.A2022033.h19v10.061.json
+++ b/examples/modis-061/modis-09A1-061/MOD09A1.A2022033.h19v10.061/MOD09A1.A2022033.h19v10.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 19,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51019010",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            2223901.039333,
+            -2223901.039333
+          ],
+          [
+            2223901.039333,
+            -1111950.519667
+          ],
+          [
+            1111950.519667,
+            -1111950.519667
+          ],
+          [
+            1111950.519667,
+            -2223901.039333
+          ],
+          [
+            2223901.039333,
+            -2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165274999,
+      0.0,
+      1111950.519667,
+      0.0,
+      -463.3127165274999,
+      -1111950.519667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -79,6 +121,265 @@
       "roles": [
         "metadata"
       ]
+    },
+    "sur_refl_b01": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b01.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1 (620-670 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b01",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b02": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b02.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2 (841-876 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b02",
+          "common_name": "nir08",
+          "center_wavelength": 0.8585,
+          "full_width_half_max": 0.35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b03": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b03.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 3 (459-479 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b03",
+          "common_name": "blue",
+          "center_wavelength": 0.469,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b04": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b04.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 4 (545-565 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b04",
+          "common_name": "green",
+          "center_wavelength": 0.555,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b05": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b05.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 5 (1230-1250 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b05",
+          "common_name": "lwir12",
+          "center_wavelength": 1.24,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b06": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b06.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 6 (1628-1652 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b06",
+          "common_name": "swir16",
+          "center_wavelength": 1.64,
+          "full_width_half_max": 0.24
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b07": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_b07.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 7 (2105-2155 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b07",
+          "common_name": "swir22",
+          "center_wavelength": 2.13,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_day_of_year": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_day_of_year.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day of the year for the pixel",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "Julian Day"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_qc_500m": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_qc_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface reflectance 500m band quality control flags",
+      "raster:bands": [
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_raz": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_raz.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "MODIS relative azimuth angle",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_state_500m": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_state_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface reflectance 500m state flags",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_szen": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_szen.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "MODIS solar zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_vzen": {
+      "href": "../../../../tests/data-files/external/MOD09A1.A2022033.h19v10.061.2022042043514_sur_refl_vzen.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "MODIS view zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +388,10 @@
     21.2909979394424,
     -9.95885098058137
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-09A1-061"
 }

--- a/examples/modis-061/modis-09A1-061/MYD09A1.A2022025.h09v08.061/MYD09A1.A2022025.h09v08.061.json
+++ b/examples/modis-061/modis-09A1-061/MYD09A1.A2022025.h09v08.061/MYD09A1.A2022025.h09v08.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51009008",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -8895604.157333,
+            0.0
+          ],
+          [
+            -8895604.157333,
+            1111950.519667
+          ],
+          [
+            -10007554.677,
+            1111950.519667
+          ],
+          [
+            -10007554.677,
+            0.0
+          ],
+          [
+            -8895604.157333,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279165,
+      0.0,
+      -10007554.677,
+      0.0,
+      -463.3127165279167,
+      1111950.519667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -79,6 +121,265 @@
       "roles": [
         "metadata"
       ]
+    },
+    "sur_refl_b01": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b01.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1 (620-670 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b01",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b02": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b02.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2 (841-876 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b02",
+          "common_name": "nir08",
+          "center_wavelength": 0.8585,
+          "full_width_half_max": 0.35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b03": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b03.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 3 (459-479 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b03",
+          "common_name": "blue",
+          "center_wavelength": 0.469,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b04": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b04.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 4 (545-565 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b04",
+          "common_name": "green",
+          "center_wavelength": 0.555,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b05": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b05.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 5 (1230-1250 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b05",
+          "common_name": "lwir12",
+          "center_wavelength": 1.24,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b06": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b06.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 6 (1628-1652 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b06",
+          "common_name": "swir16",
+          "center_wavelength": 1.64,
+          "full_width_half_max": 0.24
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b07": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_b07.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 7 (2105-2155 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b07",
+          "common_name": "swir22",
+          "center_wavelength": 2.13,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_day_of_year": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_day_of_year.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day of the year for the pixel",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "Julian Day"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_qc_500m": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_qc_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface reflectance 500m band quality control flags",
+      "raster:bands": [
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_raz": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_raz.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "MODIS relative azimuth angle",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_state_500m": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_state_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface reflectance 500m state flags",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_szen": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_szen.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "MODIS solar zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_vzen": {
+      "href": "../../../../tests/data-files/external/MYD09A1.A2022025.h09v08.061.2022035070021_sur_refl_vzen.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "MODIS view zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +388,10 @@
     -79.6923787161652,
     10.0071017643835
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-09A1-061"
 }

--- a/examples/modis-061/modis-09Q1-061/MOD09Q1.A2022033.h10v10.061/MOD09Q1.A2022033.h10v10.061.json
+++ b/examples/modis-061/modis-09Q1-061/MOD09Q1.A2022033.h10v10.061/MOD09Q1.A2022033.h10v10.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51010010",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -7783653.637667,
+            -2223901.039333
+          ],
+          [
+            -7783653.637667,
+            -1111950.519667
+          ],
+          [
+            -8895604.157333,
+            -1111950.519667
+          ],
+          [
+            -8895604.157333,
+            -2223901.039333
+          ],
+          [
+            -7783653.637667,
+            -2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      4800,
+      4800
+    ],
+    "proj:transform": [
+      231.65635826374987,
+      0.0,
+      -8895604.157333,
+      0.0,
+      -231.65635826374995,
+      -1111950.519667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -79,6 +121,82 @@
       "roles": [
         "metadata"
       ]
+    },
+    "sur_refl_b01": {
+      "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048_sur_refl_b01.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1 (620-670 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b01",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b02": {
+      "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048_sur_refl_b02.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2 (841-876 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b02",
+          "common_name": "nir08",
+          "center_wavelength": 0.8585,
+          "full_width_half_max": 0.35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_qc_250m": {
+      "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048_sur_refl_qc_250m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance 250m Band Quality Control flags",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 250
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_state_250m": {
+      "href": "../../../../tests/data-files/external/MOD09Q1.A2022033.h10v10.061.2022042044048_sur_refl_state_250m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance 250m State flags",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 250
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +205,10 @@
     -70.8054833864951,
     -9.94789001665572
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-09Q1-061"
 }

--- a/examples/modis-061/modis-09Q1-061/MYD09Q1.A2022025.h02v08.061/MYD09Q1.A2022025.h02v08.061.json
+++ b/examples/modis-061/modis-09Q1-061/MYD09Q1.A2022025.h02v08.061/MYD09Q1.A2022025.h02v08.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 2,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51002008",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -16679257.795,
+            0.0
+          ],
+          [
+            -16679257.795,
+            1111950.519667
+          ],
+          [
+            -17791208.314667,
+            1111950.519667
+          ],
+          [
+            -17791208.314667,
+            0.0
+          ],
+          [
+            -16679257.795,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      4800,
+      4800
+    ],
+    "proj:transform": [
+      231.65635826395862,
+      0.0,
+      -17791208.314667,
+      0.0,
+      -231.65635826395834,
+      1111950.519667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -79,6 +121,82 @@
       "roles": [
         "metadata"
       ]
+    },
+    "sur_refl_b01": {
+      "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917_sur_refl_b01.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1 (620-670 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b01",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_b02": {
+      "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917_sur_refl_b02.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2 (841-876 nm)",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "sur_refl_b02",
+          "common_name": "nir08",
+          "center_wavelength": 0.8585,
+          "full_width_half_max": 0.35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "sur_refl_qc_250m": {
+      "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917_sur_refl_qc_250m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance 250m Band Quality Control flags",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 250
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "sur_refl_state_250m": {
+      "href": "../../../../tests/data-files/external/MYD09Q1.A2022025.h02v08.061.2022035050917_sur_refl_state_250m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance 250m State flags",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 250
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +205,10 @@
     -149.430892222897,
     10.0131469004655
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-09Q1-061"
 }

--- a/examples/modis-061/modis-10A1-061/MOD10A1.A2022040.h11v05.061/MOD10A1.A2022040.h11v05.061.json
+++ b/examples/modis-061/modis-10A1-061/MOD10A1.A2022040.h11v05.061/MOD10A1.A2022040.h11v05.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51011005",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -6671703.118,
+            3335851.559
+          ],
+          [
+            -6671703.118,
+            4447802.078667
+          ],
+          [
+            -7783653.637667,
+            4447802.078667
+          ],
+          [
+            -7783653.637667,
+            3335851.559
+          ],
+          [
+            -6671703.118,
+            3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279169,
+      0.0,
+      -7783653.637667,
+      0.0,
+      -463.3127165279167,
+      4447802.078667
+    ],
+    "eo:cloud_cover": 24,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,115 @@
     }
   ],
   "assets": {
+    "NDSI": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_NDSI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Raw NDSI values (i.e. prior to screening).",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NDSI_Snow_Cover": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_NDSI_Snow_Cover.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gridded NDSI snow cover and data flag values.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 24,
+      "roles": [
+        "data"
+      ]
+    },
+    "NDSI_Snow_Cover_Algorithm_Flags_QA": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_NDSI_Snow_Cover_Algorithm_Flags_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Algorithm-specific bit flags set for data screens and for inland water.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NDSI_Snow_Cover_Basic_QA": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_NDSI_Snow_Cover_Basic_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "A general estimate of the quality of the algorithm result.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "best"
+        },
+        {
+          "value": 1,
+          "description": "good"
+        },
+        {
+          "value": 2,
+          "description": "ok"
+        },
+        {
+          "value": 3,
+          "description": "poor (not used)"
+        },
+        {
+          "value": 4,
+          "description": "other (not used)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Snow_Albedo_Daily_Tile": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_Snow_Albedo_Daily_Tile.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Daily snow albedo corresponding to the NDSI_Snow_Cover parameter.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 24,
+      "roles": [
+        "data"
+      ]
+    },
+    "granule_pnt": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_granule_pnt.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pointer for identifying the swath mapped into each grid cell.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026.hdf",
       "type": "application/x-hdf",
@@ -79,6 +230,20 @@
       "roles": [
         "metadata"
       ]
+    },
+    "orbit_pnt": {
+      "href": "../../../../tests/data-files/external/MOD10A1.A2022040.h11v05.061.2022042042026_orbit_pnt.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pointer to the orbit of the swath mapped into each grid cell.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +252,11 @@
     -69.0368143977928,
     40.0539543997624
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A1-061"
 }

--- a/examples/modis-061/modis-10A1-061/MYD10A1.A2022043.h21v04.061/MYD10A1.A2022043.h21v04.061.json
+++ b/examples/modis-061/modis-10A1-061/MYD10A1.A2022043.h21v04.061/MYD10A1.A2022043.h21v04.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 21,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51021004",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            4447802.078667,
+            4447802.078667
+          ],
+          [
+            4447802.078667,
+            5559752.598333
+          ],
+          [
+            3335851.559,
+            5559752.598333
+          ],
+          [
+            3335851.559,
+            4447802.078667
+          ],
+          [
+            4447802.078667,
+            4447802.078667
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279167,
+      0.0,
+      3335851.559,
+      0.0,
+      -463.31271652750013,
+      5559752.598333
+    ],
+    "eo:cloud_cover": 61,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,115 @@
     }
   ],
   "assets": {
+    "NDSI": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_NDSI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Raw NDSI values (i.e. prior to screening).",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NDSI_Snow_Cover": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_NDSI_Snow_Cover.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gridded NDSI snow cover and data flag values.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 61,
+      "roles": [
+        "data"
+      ]
+    },
+    "NDSI_Snow_Cover_Algorithm_Flags_QA": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_NDSI_Snow_Cover_Algorithm_Flags_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Algorithm-specific bit flags set for data screens and for inland water.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "NDSI_Snow_Cover_Basic_QA": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_NDSI_Snow_Cover_Basic_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "A general estimate of the quality of the algorithm result.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "best"
+        },
+        {
+          "value": 1,
+          "description": "good"
+        },
+        {
+          "value": 2,
+          "description": "ok"
+        },
+        {
+          "value": 3,
+          "description": "poor (not used)"
+        },
+        {
+          "value": 4,
+          "description": "other (not used)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Snow_Albedo_Daily_Tile": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_Snow_Albedo_Daily_Tile.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Daily snow albedo corresponding to the NDSI_Snow_Cover parameter.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 61,
+      "roles": [
+        "data"
+      ]
+    },
+    "granule_pnt": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_granule_pnt.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pointer for identifying the swath mapped into each grid cell.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657.hdf",
       "type": "application/x-hdf",
@@ -79,6 +230,20 @@
       "roles": [
         "metadata"
       ]
+    },
+    "orbit_pnt": {
+      "href": "../../../../tests/data-files/external/MYD10A1.A2022043.h21v04.061.2022045035657_orbit_pnt.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pointer to the orbit of the swath mapped into each grid cell.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +252,11 @@
     62.2504323634995,
     50.0432112964703
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A1-061"
 }

--- a/examples/modis-061/modis-10A2-061/MOD10A2.A2022033.h09v05.061/MOD10A2.A2022033.h09v05.061.json
+++ b/examples/modis-061/modis-10A2-061/MOD10A2.A2022033.h09v05.061/MOD10A2.A2022033.h09v05.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -8895604.157333,
+            3335851.559
+          ],
+          [
+            -8895604.157333,
+            4447802.078667
+          ],
+          [
+            -10007554.677,
+            4447802.078667
+          ],
+          [
+            -10007554.677,
+            3335851.559
+          ],
+          [
+            -8895604.157333,
+            3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279165,
+      0.0,
+      -10007554.677,
+      0.0,
+      -463.3127165279167,
+      4447802.078667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,76 @@
     }
   ],
   "assets": {
+    "Eight_Day_Snow_Cover": {
+      "href": "../../../../tests/data-files/external/MOD10A2.A2022033.h09v05.061.2022042050729_Eight_Day_Snow_Cover.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Snow chronology bit flags for each day in the eight-day observation period.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Maximum_Snow_Extent": {
+      "href": "../../../../tests/data-files/external/MOD10A2.A2022033.h09v05.061.2022042050729_Maximum_Snow_Extent.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Maximum snow extent over the 8-day period.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "missing data"
+        },
+        {
+          "value": 1,
+          "description": "no decision"
+        },
+        {
+          "value": 11,
+          "description": "night"
+        },
+        {
+          "value": 25,
+          "description": "no snow"
+        },
+        {
+          "value": 37,
+          "description": "lake"
+        },
+        {
+          "value": 39,
+          "description": "ocean"
+        },
+        {
+          "value": 50,
+          "description": "cloud"
+        },
+        {
+          "value": 100,
+          "description": "lake ice"
+        },
+        {
+          "value": 200,
+          "description": "snow"
+        },
+        {
+          "value": 254,
+          "description": "detector saturated"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD10A2.A2022033.h09v05.061.2022042050729.hdf",
       "type": "application/x-hdf",
@@ -87,6 +199,11 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A2-061"
 }

--- a/examples/modis-061/modis-10A2-061/MYD10A2.A2022025.h10v05.061/MYD10A2.A2022025.h10v05.061.json
+++ b/examples/modis-061/modis-10A2-061/MYD10A2.A2022025.h10v05.061/MYD10A2.A2022025.h10v05.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51010005",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -7783653.637667,
+            3335851.559
+          ],
+          [
+            -7783653.637667,
+            4447802.078667
+          ],
+          [
+            -8895604.157333,
+            4447802.078667
+          ],
+          [
+            -8895604.157333,
+            3335851.559
+          ],
+          [
+            -7783653.637667,
+            3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652749973,
+      0.0,
+      -8895604.157333,
+      0.0,
+      -463.3127165279167,
+      4447802.078667
+    ],
+    "eo:cloud_cover": 1,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,77 @@
     }
   ],
   "assets": {
+    "Eight_Day_Snow_Cover": {
+      "href": "../../../../tests/data-files/external/MYD10A2.A2022025.h10v05.061.2022035071201_Eight_Day_Snow_Cover.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Snow chronology bit flags for each day in the eight-day observation period.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Maximum_Snow_Extent": {
+      "href": "../../../../tests/data-files/external/MYD10A2.A2022025.h10v05.061.2022035071201_Maximum_Snow_Extent.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Maximum snow extent over the 8-day period.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "missing data"
+        },
+        {
+          "value": 1,
+          "description": "no decision"
+        },
+        {
+          "value": 11,
+          "description": "night"
+        },
+        {
+          "value": 25,
+          "description": "no snow"
+        },
+        {
+          "value": 37,
+          "description": "lake"
+        },
+        {
+          "value": 39,
+          "description": "ocean"
+        },
+        {
+          "value": 50,
+          "description": "cloud"
+        },
+        {
+          "value": 100,
+          "description": "lake ice"
+        },
+        {
+          "value": 200,
+          "description": "snow"
+        },
+        {
+          "value": 254,
+          "description": "detector saturated"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD10A2.A2022025.h10v05.061.2022035071201.hdf",
       "type": "application/x-hdf",
@@ -87,6 +200,11 @@
     -80.5775666708921,
     40.0637836759185
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A2-061"
 }

--- a/examples/modis-061/modis-11A1-061/MOD11A1.A2022041.h19v02.061/MOD11A1.A2022041.h19v02.061.json
+++ b/examples/modis-061/modis-11A1-061/MOD11A1.A2022041.h19v02.061/MOD11A1.A2022041.h19v02.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 19,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51019002",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            2223901.039533,
+            6671703.118599
+          ],
+          [
+            2223901.039533,
+            7783653.638366
+          ],
+          [
+            1111950.519767,
+            7783653.638366
+          ],
+          [
+            1111950.519767,
+            6671703.118599
+          ],
+          [
+            2223901.039533,
+            6671703.118599
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254331383333,
+      0.0,
+      1111950.519767,
+      0.0,
+      -926.6254331391661,
+      7783653.638366
+    ],
     "eo:cloud_cover": 49,
     "datetime": null
   },
@@ -65,6 +106,190 @@
     }
   ],
   "assets": {
+    "Clear_day_cov": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Clear_day_cov.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day clear-sky coverage",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "scale": 0.0005
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Clear_night_cov": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Clear_night_cov.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night clear-sky coverage",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "scale": 0.0005
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_angl": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Day_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of daytime Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_time": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Day_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "(local solar) Time of daytime Land-surface Temperature observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_31": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Emis_31.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 31 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_32": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Emis_32.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 32 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Day_1km": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_LST_Day_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Daily daytime 1km grid Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "LST_Night_1km": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_LST_Night_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Daily nighttime 1km grid Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "Night_view_angl": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Night_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of nighttime Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Night_view_time": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_Night_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "(local solar) Time of nighttime Landsurface Temperature observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Day": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_QC_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for daytime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Night": {
+      "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544_QC_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for nighttime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD11A1.A2022041.h19v02.061.2022042095544.hdf",
       "type": "application/x-hdf",
@@ -89,7 +314,9 @@
     69.9958333333333
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "modis-11A1-061"
 }

--- a/examples/modis-061/modis-11A1-061/MYD11A1.A2022039.h21v07.061/MYD11A1.A2022039.h21v07.061.json
+++ b/examples/modis-061/modis-11A1-061/MYD11A1.A2022039.h21v07.061/MYD11A1.A2022039.h21v07.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 21,
     "modis:vertical-tile": 7,
     "modis:tile-id": "51021007",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            4447802.079066,
+            1111950.519767
+          ],
+          [
+            4447802.079066,
+            2223901.039533
+          ],
+          [
+            3335851.5593,
+            2223901.039533
+          ],
+          [
+            3335851.5593,
+            1111950.519767
+          ],
+          [
+            4447802.079066,
+            1111950.519767
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254331383334,
+      0.0,
+      3335851.5593,
+      0.0,
+      -926.6254331383333,
+      2223901.039533
+    ],
     "eo:cloud_cover": 11,
     "datetime": null
   },
@@ -65,6 +106,190 @@
     }
   ],
   "assets": {
+    "Clear_day_cov": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Clear_day_cov.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day clear-sky coverage",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "scale": 0.0005
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Clear_night_cov": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Clear_night_cov.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night clear-sky coverage",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "scale": 0.0005
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_angl": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Day_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of daytime Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_time": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Day_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "(local solar) Time of daytime Land-surface Temperature observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_31": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Emis_31.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 31 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_32": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Emis_32.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 32 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Day_1km": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_LST_Day_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Daily daytime 1km grid Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "LST_Night_1km": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_LST_Night_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Daily nighttime 1km grid Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "Night_view_angl": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Night_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of nighttime Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Night_view_time": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_Night_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "(local solar) Time of nighttime Landsurface Temperature observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Day": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_QC_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for daytime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Night": {
+      "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419_QC_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for nighttime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD11A1.A2022039.h21v07.061.2022040192419.hdf",
       "type": "application/x-hdf",
@@ -89,7 +314,9 @@
     19.9958333333333
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "modis-11A1-061"
 }

--- a/examples/modis-061/modis-11A2-061/MOD11A2.A2022033.h19v10.061/MOD11A2.A2022033.h19v10.061.json
+++ b/examples/modis-061/modis-11A2-061/MOD11A2.A2022033.h19v10.061/MOD11A2.A2022033.h19v10.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 19,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51019010",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            2223901.039533,
+            -2223901.039533
+          ],
+          [
+            2223901.039533,
+            -1111950.519767
+          ],
+          [
+            1111950.519767,
+            -1111950.519767
+          ],
+          [
+            1111950.519767,
+            -2223901.039533
+          ],
+          [
+            2223901.039533,
+            -2223901.039533
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254331383333,
+      0.0,
+      1111950.519767,
+      0.0,
+      -926.6254331383333,
+      -1111950.519767
+    ],
     "eo:cloud_cover": 19,
     "datetime": null
   },
@@ -65,6 +106,188 @@
     }
   ],
   "assets": {
+    "Clear_sky_days": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Clear_sky_days.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "the days in clear-sky conditions and with validate LSTs",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Clear_sky_nights": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Clear_sky_nights.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "the nights in clear-sky conditions and with validate LSTs",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_angl": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Day_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average view zenith angle of daytime Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_time": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Day_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average time of daytime Landsurface Temperature observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_31": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Emis_31.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 31 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_32": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Emis_32.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 32 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Day_1km": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_LST_Day_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "8-day daytime 1km grid Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "LST_Night_1km": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_LST_Night_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "8-day nighttime 1km grid Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "Night_view_angl": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Night_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of nighttime Land-surface Temperature ",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Night_view_time": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_Night_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average view zenith angle of nighttime Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Day": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_QC_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for daytime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Night": {
+      "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121_QC_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for nighttime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD11A2.A2022033.h19v10.061.2022042044121.hdf",
       "type": "application/x-hdf",
@@ -89,7 +312,9 @@
     -10.0041666666667
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "modis-11A2-061"
 }

--- a/examples/modis-061/modis-11A2-061/MYD11A2.A2022025.h17v00.061/MYD11A2.A2022025.h17v00.061.json
+++ b/examples/modis-061/modis-11A2-061/MYD11A2.A2022025.h17v00.061/MYD11A2.A2022025.h17v00.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 17,
     "modis:vertical-tile": 0,
     "modis:tile-id": "51017000",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            0.0,
+            8895604.158132
+          ],
+          [
+            0.0,
+            10007554.677899
+          ],
+          [
+            -1111950.519767,
+            10007554.677899
+          ],
+          [
+            -1111950.519767,
+            8895604.158132
+          ],
+          [
+            0.0,
+            8895604.158132
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254331391667,
+      0.0,
+      -1111950.519767,
+      0.0,
+      -926.6254331391661,
+      10007554.677899
+    ],
     "eo:cloud_cover": 16,
     "datetime": null
   },
@@ -65,6 +106,188 @@
     }
   ],
   "assets": {
+    "Clear_sky_days": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Clear_sky_days.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "the days in clear-sky conditions and with validate LSTs",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Clear_sky_nights": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Clear_sky_nights.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "the nights in clear-sky conditions and with validate LSTs",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_angl": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Day_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average view zenith angle of daytime Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Day_view_time": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Day_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average time of daytime Landsurface Temperature observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_31": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Emis_31.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 31 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_32": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Emis_32.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Band 32 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Day_1km": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_LST_Day_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "8-day daytime 1km grid Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "LST_Night_1km": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_LST_Night_1km.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "8-day nighttime 1km grid Landsurface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data",
+        "temperature"
+      ]
+    },
+    "Night_view_angl": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Night_view_angl.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of nighttime Land-surface Temperature ",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Night_view_time": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_Night_view_time.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average view zenith angle of nighttime Land-surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Day": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_QC_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for daytime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Night": {
+      "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130_QC_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control for nighttime LST and emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD11A2.A2022025.h17v00.061.2022035054130.hdf",
       "type": "application/x-hdf",
@@ -89,7 +312,9 @@
     89.9875
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "modis-11A2-061"
 }

--- a/examples/modis-061/modis-13A1-061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
+++ b/examples/modis-061/modis-13A1-061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
@@ -55,7 +55,7 @@
       -463.3127165279167,
       -2223901.039333
     ],
-    "eo:cloud_cover": 1,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/examples/modis-061/modis-13A1-061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
+++ b/examples/modis-061/modis-13A1-061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51012011",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -5559752.598333,
+            -3335851.559
+          ],
+          [
+            -5559752.598333,
+            -2223901.039333
+          ],
+          [
+            -6671703.118,
+            -2223901.039333
+          ],
+          [
+            -6671703.118,
+            -3335851.559
+          ],
+          [
+            -5559752.598333,
+            -3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279165,
+      0.0,
+      -6671703.118,
+      0.0,
+      -463.3127165279167,
+      -2223901.039333
+    ],
+    "eo:cloud_cover": 1,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,220 @@
     }
   ],
   "assets": {
+    "500m_16_days_EVI": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_EVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "500m 16 days EVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "EVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_MIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_MIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 7",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_NDVI": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_NDVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "500m 16 days NDVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "NDVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_NIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_NIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_VI_Quality": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_VI_Quality.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "VI quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_blue_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_blue_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 3",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_composite_day_of_the_year": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_composite_day_of_the_year.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day of year VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Julian Day"
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_pixel_reliability": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_pixel_reliability.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality reliability of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int8",
+          "spatial_resolution": 500,
+          "unit": "Rank"
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Good data, use with confidence"
+        },
+        {
+          "value": 1,
+          "description": "Marginal data, useful, but look at other QA information"
+        },
+        {
+          "value": 2,
+          "description": "Snow/Ice Target covered with snow/ice"
+        },
+        {
+          "value": 3,
+          "description": "Cloudy data"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_red_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_red_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_relative_azimuth_angle": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_relative_azimuth_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Relative azimuth angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_sun_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_sun_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Sun zenith angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_view_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214_500m_16_days_view_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of VI Pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD13A1.A2022017.h12v11.061.2022034232214.hdf",
       "type": "application/x-hdf",
@@ -87,6 +343,11 @@
     -52.9919478058681,
     -19.9038664997372
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-13A1-061"
 }

--- a/examples/modis-061/modis-13A1-061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
+++ b/examples/modis-061/modis-13A1-061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 25,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51025002",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            8895604.157333,
+            6671703.118
+          ],
+          [
+            8895604.157333,
+            7783653.637667
+          ],
+          [
+            7783653.637667,
+            7783653.637667
+          ],
+          [
+            7783653.637667,
+            6671703.118
+          ],
+          [
+            8895604.157333,
+            6671703.118
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652749973,
+      0.0,
+      7783653.637667,
+      0.0,
+      -463.3127165279169,
+      7783653.637667
+    ],
+    "eo:cloud_cover": 46,
     "datetime": null
   },
   "geometry": {
@@ -90,6 +132,220 @@
     }
   ],
   "assets": {
+    "500m_16_days_EVI": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_EVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "500m 16 days EVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "EVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_MIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_MIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 7",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_NDVI": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_NDVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "500m 16 days NDVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "NDVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_NIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_NIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_VI_Quality": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_VI_Quality.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "VI quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_blue_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_blue_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 3",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_composite_day_of_the_year": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_composite_day_of_the_year.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day of year VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Julian Day"
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_pixel_reliability": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_pixel_reliability.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality reliability of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int8",
+          "spatial_resolution": 500,
+          "unit": "Rank"
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Good data, use with confidence"
+        },
+        {
+          "value": 1,
+          "description": "Marginal data, useful, but look at other QA information"
+        },
+        {
+          "value": 2,
+          "description": "Snow/Ice Target covered with snow/ice"
+        },
+        {
+          "value": 3,
+          "description": "Cloudy data"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_red_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_red_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_relative_azimuth_angle": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_relative_azimuth_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Relative azimuth angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_sun_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_sun_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Sun zenith angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
+    "500m_16_days_view_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925_500m_16_days_view_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of VI Pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 46,
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD13A1.A2022009.h25v02.061.2022028071925.hdf",
       "type": "application/x-hdf",
@@ -113,6 +369,11 @@
     -176.534172118079,
     69.2113905326394
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-13A1-061"
 }

--- a/examples/modis-061/modis-13A1-061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
+++ b/examples/modis-061/modis-13A1-061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
@@ -55,7 +55,7 @@
       -463.3127165279169,
       7783653.637667
     ],
-    "eo:cloud_cover": 46,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
+++ b/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
@@ -55,7 +55,7 @@
       -231.65635826395834,
       -2223901.039333
     ],
-    "eo:cloud_cover": 1,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
+++ b/examples/modis-061/modis-13Q1-061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51012011",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -5559752.598333,
+            -3335851.559
+          ],
+          [
+            -5559752.598333,
+            -2223901.039333
+          ],
+          [
+            -6671703.118,
+            -2223901.039333
+          ],
+          [
+            -6671703.118,
+            -3335851.559
+          ],
+          [
+            -5559752.598333,
+            -3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      4800,
+      4800
+    ],
+    "proj:transform": [
+      231.65635826395825,
+      0.0,
+      -6671703.118,
+      0.0,
+      -231.65635826395834,
+      -2223901.039333
+    ],
+    "eo:cloud_cover": 1,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,220 @@
     }
   ],
   "assets": {
+    "250m_16_days_EVI": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_EVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "16 day EVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "EVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_MIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_MIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 7",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_NDVI": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_NDVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "16 day NDVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "NDVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_NIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_NIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_VI_Quality": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_VI_Quality.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "VI quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 250
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_blue_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_blue_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 3",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_composite_day_of_the_year": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_composite_day_of_the_year.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day of year VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Julian Day"
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_pixel_reliability": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_pixel_reliability.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality reliability of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int8",
+          "spatial_resolution": 250,
+          "unit": "Rank"
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Good data, use with confidence"
+        },
+        {
+          "value": 1,
+          "description": "Marginal data, useful, but look at other QA information"
+        },
+        {
+          "value": 2,
+          "description": "Snow/Ice Target covered with snow/ice"
+        },
+        {
+          "value": 3,
+          "description": "Cloudy data"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_red_reflectance": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_red_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_relative_azimuth_angle": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_relative_azimuth_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Relative azimuth angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_sun_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_sun_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Sun zenith angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_view_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400_250m_16_days_view_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of VI Pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 1,
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD13Q1.A2022017.h12v11.061.2022034232400.hdf",
       "type": "application/x-hdf",
@@ -87,6 +343,11 @@
     -52.9919478058681,
     -19.9038664997372
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-13Q1-061"
 }

--- a/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
+++ b/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51009006",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -8895604.157333,
+            2223901.039333
+          ],
+          [
+            -8895604.157333,
+            3335851.559
+          ],
+          [
+            -10007554.677,
+            3335851.559
+          ],
+          [
+            -10007554.677,
+            2223901.039333
+          ],
+          [
+            -8895604.157333,
+            2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      4800,
+      4800
+    ],
+    "proj:transform": [
+      231.65635826395825,
+      0.0,
+      -10007554.677,
+      0.0,
+      -231.65635826395834,
+      3335851.559
+    ],
+    "eo:cloud_cover": 2,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,220 @@
     }
   ],
   "assets": {
+    "250m_16_days_EVI": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_EVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "16 day EVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "EVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_MIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_MIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 7",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_NDVI": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_NDVI.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "16 day NDVI",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "NDVI",
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_NIR_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_NIR_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 2",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_VI_Quality": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_VI_Quality.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "VI quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 250
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_blue_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_blue_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 3",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_composite_day_of_the_year": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_composite_day_of_the_year.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day of year VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Julian Day"
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_pixel_reliability": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_pixel_reliability.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality reliability of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int8",
+          "spatial_resolution": 250,
+          "unit": "Rank"
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Good data, use with confidence"
+        },
+        {
+          "value": 1,
+          "description": "Marginal data, useful, but look at other QA information"
+        },
+        {
+          "value": 2,
+          "description": "Snow/Ice Target covered with snow/ice"
+        },
+        {
+          "value": 3,
+          "description": "Cloudy data"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_red_reflectance": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_red_reflectance.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Surface Reflectance Band 1",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "scale": 0.0001
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_relative_azimuth_angle": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_relative_azimuth_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Relative azimuth angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_sun_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_sun_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Sun zenith angle of VI pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
+    "250m_16_days_view_zenith_angle": {
+      "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010_250m_16_days_view_zenith_angle.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "View zenith angle of VI Pixel",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 250,
+          "unit": "Degree",
+          "scale": 0.01
+        }
+      ],
+      "eo:cloud_cover": 2,
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD13Q1.A2022009.h09v06.061.2022028072010.hdf",
       "type": "application/x-hdf",
@@ -87,6 +343,11 @@
     -84.8251194107616,
     30.0438375723808
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-13Q1-061"
 }

--- a/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
+++ b/examples/modis-061/modis-13Q1-061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
@@ -55,7 +55,7 @@
       -231.65635826395834,
       3335851.559
     ],
-    "eo:cloud_cover": 2,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/examples/modis-061/modis-14A1-061/MOD14A1.A2022033.h11v05.061/MOD14A1.A2022033.h11v05.061.json
+++ b/examples/modis-061/modis-14A1-061/MOD14A1.A2022033.h11v05.061/MOD14A1.A2022033.h11v05.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51011005",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -6671703.118,
+            3335851.559
+          ],
+          [
+            -6671703.118,
+            4447802.078667
+          ],
+          [
+            -7783653.637667,
+            4447802.078667
+          ],
+          [
+            -7783653.637667,
+            3335851.559
+          ],
+          [
+            -6671703.118,
+            3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254330558338,
+      0.0,
+      -7783653.637667,
+      0.0,
+      -926.6254330558334,
+      4447802.078667
+    ],
     "datetime": null
   },
   "geometry": {
@@ -64,6 +105,190 @@
     }
   ],
   "assets": {
+    "FireMask": {
+      "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759_FireMask.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Confidence of fire",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Not processed (missing input data)"
+        },
+        {
+          "value": 1,
+          "description": "Not processed (obsolete; not used since Collection 1)"
+        },
+        {
+          "value": 2,
+          "description": "Not processed (other reason)"
+        },
+        {
+          "value": 3,
+          "description": "Non-fire water pixel"
+        },
+        {
+          "value": 4,
+          "description": "Cloud (land or water)"
+        },
+        {
+          "value": 5,
+          "description": "Non-fire land pixel"
+        },
+        {
+          "value": 6,
+          "description": "Unknown (land or water)"
+        },
+        {
+          "value": 7,
+          "description": "Fire (low confidence, land or water)"
+        },
+        {
+          "value": 8,
+          "description": "Fire (nominal confidence, land or water)"
+        },
+        {
+          "value": 9,
+          "description": "Fire (high confidence, land or water)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MaxFRP": {
+      "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759_MaxFRP.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Maximum Fire Radiative Power",
+      "raster:bands": [
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QA": {
+      "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pixel quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759.hdf",
       "type": "application/x-hdf",
@@ -79,6 +304,48 @@
       "roles": [
         "metadata"
       ]
+    },
+    "sample": {
+      "href": "../../../../tests/data-files/external/MOD14A1.A2022033.h11v05.061.2022041234759_sample.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Position of fire pixel within scan",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -87,6 +354,10 @@
     -69.0368143977928,
     40.0539543997624
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-14A1-061"
 }

--- a/examples/modis-061/modis-14A1-061/MYD14A1.A2022025.h01v07.061/MYD14A1.A2022025.h01v07.061.json
+++ b/examples/modis-061/modis-14A1-061/MYD14A1.A2022025.h01v07.061/MYD14A1.A2022025.h01v07.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 1,
     "modis:vertical-tile": 7,
     "modis:tile-id": "51001007",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -17791208.314667,
+            1111950.519667
+          ],
+          [
+            -17791208.314667,
+            2223901.039333
+          ],
+          [
+            -18903158.834333,
+            2223901.039333
+          ],
+          [
+            -18903158.834333,
+            1111950.519667
+          ],
+          [
+            -17791208.314667,
+            1111950.519667
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254330549979,
+      0.0,
+      -18903158.834333,
+      0.0,
+      -926.6254330549998,
+      2223901.039333
+    ],
     "datetime": null
   },
   "geometry": {
@@ -90,6 +131,190 @@
     }
   ],
   "assets": {
+    "FireMask": {
+      "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141_FireMask.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Confidence of fire",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Not processed (missing input data)"
+        },
+        {
+          "value": 1,
+          "description": "Not processed (obsolete; not used since Collection 1)"
+        },
+        {
+          "value": 2,
+          "description": "Not processed (other reason)"
+        },
+        {
+          "value": 3,
+          "description": "Non-fire water pixel"
+        },
+        {
+          "value": 4,
+          "description": "Cloud (land or water)"
+        },
+        {
+          "value": 5,
+          "description": "Non-fire land pixel"
+        },
+        {
+          "value": 6,
+          "description": "Unknown (land or water)"
+        },
+        {
+          "value": 7,
+          "description": "Fire (low confidence, land or water)"
+        },
+        {
+          "value": 8,
+          "description": "Fire (nominal confidence, land or water)"
+        },
+        {
+          "value": 9,
+          "description": "Fire (high confidence, land or water)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MaxFRP": {
+      "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141_MaxFRP.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Maximum Fire Radiative Power",
+      "raster:bands": [
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        },
+        {
+          "data_type": "uint32",
+          "spatial_resolution": 1000,
+          "unit": "Megawatts",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QA": {
+      "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pixel quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141.hdf",
       "type": "application/x-hdf",
@@ -105,6 +330,48 @@
       "roles": [
         "metadata"
       ]
+    },
+    "sample": {
+      "href": "../../../../tests/data-files/external/MYD14A1.A2022025.h01v07.061.2022035001141_sample.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Position of fire pixel within scan",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        },
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
     }
   },
   "bbox": [
@@ -113,6 +380,10 @@
     -162.21824805558,
     20.2678775712419
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-14A1-061"
 }

--- a/examples/modis-061/modis-14A2-061/MOD14A2.A2022033.h21v05.061/MOD14A2.A2022033.h21v05.061.json
+++ b/examples/modis-061/modis-14A2-061/MOD14A2.A2022033.h21v05.061/MOD14A2.A2022033.h21v05.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 21,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51021005",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            4447802.078667,
+            3335851.559
+          ],
+          [
+            4447802.078667,
+            4447802.078667
+          ],
+          [
+            3335851.559,
+            4447802.078667
+          ],
+          [
+            3335851.559,
+            3335851.559
+          ],
+          [
+            4447802.078667,
+            3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254330558334,
+      0.0,
+      3335851.559,
+      0.0,
+      -926.6254330558334,
+      4447802.078667
+    ],
     "datetime": null
   },
   "geometry": {
@@ -64,6 +105,76 @@
     }
   ],
   "assets": {
+    "FireMask": {
+      "href": "../../../../tests/data-files/external/MOD14A2.A2022033.h21v05.061.2022041234800_FireMask.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Confidence of fire",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Not processed (missing input data)"
+        },
+        {
+          "value": 1,
+          "description": "Not processed (obsolete; not used since Collection 1)"
+        },
+        {
+          "value": 2,
+          "description": "Not processed (other reason)"
+        },
+        {
+          "value": 3,
+          "description": "Non-fire water pixel"
+        },
+        {
+          "value": 4,
+          "description": "Cloud (land or water)"
+        },
+        {
+          "value": 5,
+          "description": "Non-fire land pixel"
+        },
+        {
+          "value": 6,
+          "description": "Unknown (land or water)"
+        },
+        {
+          "value": 7,
+          "description": "Fire (low confidence, land or water)"
+        },
+        {
+          "value": 8,
+          "description": "Fire (nominal confidence, land or water)"
+        },
+        {
+          "value": 9,
+          "description": "Fire (high confidence, land or water)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QA": {
+      "href": "../../../../tests/data-files/external/MOD14A2.A2022033.h21v05.061.2022041234800_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pixel quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD14A2.A2022033.h21v05.061.2022041234800.hdf",
       "type": "application/x-hdf",
@@ -87,6 +198,10 @@
     52.2322788546416,
     40.0278035903489
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-14A2-061"
 }

--- a/examples/modis-061/modis-14A2-061/MYD14A2.A2022025.h03v09.061/MYD14A2.A2022025.h03v09.061.json
+++ b/examples/modis-061/modis-14A2-061/MYD14A2.A2022025.h03v09.061/MYD14A2.A2022025.h03v09.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 3,
     "modis:vertical-tile": 9,
     "modis:tile-id": "51003009",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -15567307.275333,
+            -1111950.519667
+          ],
+          [
+            -15567307.275333,
+            0.0
+          ],
+          [
+            -16679257.795,
+            0.0
+          ],
+          [
+            -16679257.795,
+            -1111950.519667
+          ],
+          [
+            -15567307.275333,
+            -1111950.519667
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.625433055833,
+      0.0,
+      -16679257.795,
+      0.0,
+      -926.6254330558334,
+      0.0
+    ],
     "datetime": null
   },
   "geometry": {
@@ -64,6 +105,76 @@
     }
   ],
   "assets": {
+    "FireMask": {
+      "href": "../../../../tests/data-files/external/MYD14A2.A2022025.h03v09.061.2022035001140_FireMask.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Confidence of fire",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Not processed (missing input data)"
+        },
+        {
+          "value": 1,
+          "description": "Not processed (obsolete; not used since Collection 1)"
+        },
+        {
+          "value": 2,
+          "description": "Not processed (other reason)"
+        },
+        {
+          "value": 3,
+          "description": "Non-fire water pixel"
+        },
+        {
+          "value": 4,
+          "description": "Cloud (land or water)"
+        },
+        {
+          "value": 5,
+          "description": "Non-fire land pixel"
+        },
+        {
+          "value": 6,
+          "description": "Unknown (land or water)"
+        },
+        {
+          "value": 7,
+          "description": "Fire (low confidence, land or water)"
+        },
+        {
+          "value": 8,
+          "description": "Fire (nominal confidence, land or water)"
+        },
+        {
+          "value": 9,
+          "description": "Fire (high confidence, land or water)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QA": {
+      "href": "../../../../tests/data-files/external/MYD14A2.A2022025.h03v09.061.2022035001140_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Pixel quality indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD14A2.A2022025.h03v09.061.2022035001140.hdf",
       "type": "application/x-hdf",
@@ -87,6 +198,10 @@
     -139.468212625991,
     0.0140311075676572
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
+  ],
   "collection": "modis-14A2-061"
 }

--- a/examples/modis-061/modis-15A2H-061/MCD15A2H.A2022025.h01v11.061/MCD15A2H.A2022025.h01v11.061.json
+++ b/examples/modis-061/modis-15A2H-061/MCD15A2H.A2022025.h01v11.061/MCD15A2H.A2022025.h01v11.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 1,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51001011",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -17791208.314667,
+            -3335851.559
+          ],
+          [
+            -17791208.314667,
+            -2223901.039333
+          ],
+          [
+            -18903158.834333,
+            -2223901.039333
+          ],
+          [
+            -18903158.834333,
+            -3335851.559
+          ],
+          [
+            -17791208.314667,
+            -3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652749894,
+      0.0,
+      -18903158.834333,
+      0.0,
+      -463.3127165279167,
+      -2223901.039333
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -90,6 +132,100 @@
     }
   ],
   "assets": {
+    "FparExtra_QC": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702_FparExtra_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Extra detail Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparLai_QC": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702_FparLai_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702_FparStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of FPAR",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Fpar_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702_Fpar_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Fraction of Photosynthetically Active Radiation",
+      "description": "The fraction of incident photosynthetically active radiation (400-700 nm) absorbed by the green elements of a vegetation canopy.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LaiStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702_LaiStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Lai_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702_Lai_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Leaf Area Index",
+      "description": "The one-sided green leaf area per unit ground area in broadleaf canopies and as one-half the total needle surface area per unit ground area in coniferous canopies",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MCD15A2H.A2022025.h01v11.061.2022035062702.hdf",
       "type": "application/x-hdf",
@@ -113,6 +249,10 @@
     -169.997993708017,
     -19.9296251074518
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-15A2H-061"
 }

--- a/examples/modis-061/modis-15A2H-061/MOD15A2H.A2022033.h13v10.061/MOD15A2H.A2022033.h13v10.061.json
+++ b/examples/modis-061/modis-15A2H-061/MOD15A2H.A2022033.h13v10.061/MOD15A2H.A2022033.h13v10.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 13,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51013010",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -4447802.078667,
+            -2223901.039333
+          ],
+          [
+            -4447802.078667,
+            -1111950.519667
+          ],
+          [
+            -5559752.598333,
+            -1111950.519667
+          ],
+          [
+            -5559752.598333,
+            -2223901.039333
+          ],
+          [
+            -4447802.078667,
+            -2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652750013,
+      0.0,
+      -5559752.598333,
+      0.0,
+      -463.3127165274999,
+      -1111950.519667
+    ],
+    "eo:cloud_cover": 29,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,100 @@
     }
   ],
   "assets": {
+    "FparExtra_QC": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937_FparExtra_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Extra detail Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparLai_QC": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937_FparLai_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937_FparStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of FPAR",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Fpar_500m": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937_Fpar_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Fraction of Photosynthetically Active Radiation",
+      "description": "The fraction of incident photosynthetically active radiation (400-700 nm) absorbed by the green elements of a vegetation canopy.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LaiStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937_LaiStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Lai_500m": {
+      "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937_Lai_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Leaf Area Index",
+      "description": "The one-sided green leaf area per unit ground area in broadleaf canopies and as one-half the total needle surface area per unit ground area in coniferous canopies",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD15A2H.A2022033.h13v10.061.2022042045937.hdf",
       "type": "application/x-hdf",
@@ -87,6 +223,10 @@
     -40.4553463288051,
     -9.95361312745358
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-15A2H-061"
 }

--- a/examples/modis-061/modis-15A2H-061/MYD15A2H.A2022025.h22v08.061/MYD15A2H.A2022025.h22v08.061.json
+++ b/examples/modis-061/modis-15A2H-061/MYD15A2H.A2022025.h22v08.061/MYD15A2H.A2022025.h22v08.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 22,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51022008",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            5559752.598333,
+            0.0
+          ],
+          [
+            5559752.598333,
+            1111950.519667
+          ],
+          [
+            4447802.078667,
+            1111950.519667
+          ],
+          [
+            4447802.078667,
+            0.0
+          ],
+          [
+            5559752.598333,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652750013,
+      0.0,
+      4447802.078667,
+      0.0,
+      -463.3127165279167,
+      1111950.519667
+    ],
+    "eo:cloud_cover": 2,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,100 @@
     }
   ],
   "assets": {
+    "FparExtra_QC": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026_FparExtra_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Extra detail Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparLai_QC": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026_FparLai_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026_FparStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of FPAR",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Fpar_500m": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026_Fpar_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Fraction of Photosynthetically Active Radiation",
+      "description": "The fraction of incident photosynthetically active radiation (400-700 nm) absorbed by the green elements of a vegetation canopy.",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LaiStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026_LaiStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Lai_500m": {
+      "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026_Lai_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Leaf Area Index",
+      "description": "The one-sided green leaf area per unit ground area in broadleaf canopies and as one-half the total needle surface area per unit ground area in coniferous canopies",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD15A2H.A2022025.h22v08.061.2022035072026.hdf",
       "type": "application/x-hdf",
@@ -87,6 +223,10 @@
     50.7804337536263,
     10.0038388277022
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-15A2H-061"
 }

--- a/examples/modis-061/modis-15A3H-061/MCD15A3H.A2022033.h12v10.061/MCD15A3H.A2022033.h12v10.061.json
+++ b/examples/modis-061/modis-15A3H-061/MCD15A3H.A2022033.h12v10.061/MCD15A3H.A2022033.h12v10.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51012010",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -5559752.598333,
+            -2223901.039333
+          ],
+          [
+            -5559752.598333,
+            -1111950.519667
+          ],
+          [
+            -6671703.118,
+            -1111950.519667
+          ],
+          [
+            -6671703.118,
+            -2223901.039333
+          ],
+          [
+            -5559752.598333,
+            -2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279165,
+      0.0,
+      -6671703.118,
+      0.0,
+      -463.3127165274999,
+      -1111950.519667
+    ],
+    "eo:cloud_cover": 39,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,98 @@
     }
   ],
   "assets": {
+    "FparExtra_QC": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215_FparExtra_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Extra detail Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparLai_QC": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215_FparLai_QC.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality for FPAR and LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "FparStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215_FparStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of FPAR",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Fpar_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215_Fpar_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Fraction of Photosynthetically Active Radiation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent",
+          "scale": 0.01
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LaiStdDev_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215_LaiStdDev_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Standard deviation of LAI",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Lai_500m": {
+      "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215_Lai_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Leaf Area Index",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "m^2/m^2",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MCD15A3H.A2022033.h12v10.061.2022039062215.hdf",
       "type": "application/x-hdf",
@@ -87,6 +221,10 @@
     -50.5717093742954,
     -9.95174301126409
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-15A3H-061"
 }

--- a/examples/modis-061/modis-16A3GF-061/MOD16A3GF.A2021001.h11v02.061/MOD16A3GF.A2021001.h11v02.061.json
+++ b/examples/modis-061/modis-16A3GF-061/MOD16A3GF.A2021001.h11v02.061/MOD16A3GF.A2021001.h11v02.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51011002",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -6671703.118,
+            6671703.118
+          ],
+          [
+            -6671703.118,
+            7783653.637667
+          ],
+          [
+            -7783653.637667,
+            7783653.637667
+          ],
+          [
+            -7783653.637667,
+            6671703.118
+          ],
+          [
+            -6671703.118,
+            6671703.118
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279169,
+      0.0,
+      -7783653.637667,
+      0.0,
+      -463.3127165279169,
+      7783653.637667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -90,6 +132,85 @@
     }
   ],
   "assets": {
+    "ET_500m": {
+      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208_ET_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Total of Evapotranspiration",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "kg/m^2/year",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "ET_QC_500m": {
+      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208_ET_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Evapotranspiration Quality Assessment",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LE_500m": {
+      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208_LE_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average of Latent Heat Flux",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "J/m^2/day",
+          "scale": 10000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PET_500m": {
+      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208_PET_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Total Potential Evapotranspiration",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "kg/m^2/year",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PLE_500m": {
+      "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208_PLE_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average of Potential Latent Heat Flux",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "J/m^2/day",
+          "scale": 10000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD16A3GF.A2021001.h11v02.061.2022024075208.hdf",
       "type": "application/x-hdf",
@@ -113,6 +234,10 @@
     -109.906882828253,
     75.55535641397
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-16A3GF-061"
 }

--- a/examples/modis-061/modis-16A3GF-061/MYD16A3GF.A2021001.h11v02.061/MYD16A3GF.A2021001.h11v02.061.json
+++ b/examples/modis-061/modis-16A3GF-061/MYD16A3GF.A2021001.h11v02.061/MYD16A3GF.A2021001.h11v02.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51011002",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -6671703.118,
+            6671703.118
+          ],
+          [
+            -6671703.118,
+            7783653.637667
+          ],
+          [
+            -7783653.637667,
+            7783653.637667
+          ],
+          [
+            -7783653.637667,
+            6671703.118
+          ],
+          [
+            -6671703.118,
+            6671703.118
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279169,
+      0.0,
+      -7783653.637667,
+      0.0,
+      -463.3127165279169,
+      7783653.637667
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -90,6 +132,85 @@
     }
   ],
   "assets": {
+    "ET_500m": {
+      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526_ET_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Total of Evapotranspiration",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "kg/m^2/year",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "ET_QC_500m": {
+      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526_ET_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Evapotranspiration Quality Assessment",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LE_500m": {
+      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526_LE_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average of Latent Heat Flux",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "J/m^2/day",
+          "scale": 10000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PET_500m": {
+      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526_PET_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Total Potential Evapotranspiration",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "kg/m^2/year",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PLE_500m": {
+      "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526_PLE_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average of Potential Latent Heat Flux",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "J/m^2/day",
+          "scale": 10000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD16A3GF.A2021001.h11v02.061.2022024220526.hdf",
       "type": "application/x-hdf",
@@ -113,6 +234,10 @@
     -109.906882828253,
     75.55535641397
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-16A3GF-061"
 }

--- a/examples/modis-061/modis-17A2H-061/MOD17A2H.A2022025.h08v05.061/MOD17A2H.A2022025.h08v05.061.json
+++ b/examples/modis-061/modis-17A2H-061/MOD17A2H.A2022025.h08v05.061/MOD17A2H.A2022025.h08v05.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 8,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51008005",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -10007554.677,
+            3335851.559
+          ],
+          [
+            -10007554.677,
+            4447802.078667
+          ],
+          [
+            -11119505.196667,
+            4447802.078667
+          ],
+          [
+            -11119505.196667,
+            3335851.559
+          ],
+          [
+            -10007554.677,
+            3335851.559
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652791725,
+      0.0,
+      -11119505.196667,
+      0.0,
+      -463.3127165279167,
+      4447802.078667
+    ],
+    "eo:cloud_cover": 59,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,52 @@
     }
   ],
   "assets": {
+    "Gpp_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002_Gpp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gross Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PsnNet_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002_PsnNet_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Net Photosynthesis",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Psn_QC_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002_Psn_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD17A2H.A2022025.h08v05.061.2022035065002.hdf",
       "type": "application/x-hdf",
@@ -87,6 +175,10 @@
     -103.699828723654,
     40.0852255853565
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-17A2H-061"
 }

--- a/examples/modis-061/modis-17A2H-061/MYD17A2H.A2022025.h22v08.061/MYD17A2H.A2022025.h22v08.061.json
+++ b/examples/modis-061/modis-17A2H-061/MYD17A2H.A2022025.h22v08.061/MYD17A2H.A2022025.h22v08.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 22,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51022008",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            5559752.598333,
+            0.0
+          ],
+          [
+            5559752.598333,
+            1111950.519667
+          ],
+          [
+            4447802.078667,
+            1111950.519667
+          ],
+          [
+            4447802.078667,
+            0.0
+          ],
+          [
+            5559752.598333,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652750013,
+      0.0,
+      4447802.078667,
+      0.0,
+      -463.3127165279167,
+      1111950.519667
+    ],
+    "eo:cloud_cover": 40,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,52 @@
     }
   ],
   "assets": {
+    "Gpp_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601_Gpp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gross Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PsnNet_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601_PsnNet_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Net Photosynthesis",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Psn_QC_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601_Psn_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD17A2H.A2022025.h22v08.061.2022035120601.hdf",
       "type": "application/x-hdf",
@@ -87,6 +175,10 @@
     50.7804337536263,
     10.0038388277022
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-17A2H-061"
 }

--- a/examples/modis-061/modis-17A2HGF-061/MOD17A2HGF.A2021361.h10v06.061/MOD17A2HGF.A2021361.h10v06.061.json
+++ b/examples/modis-061/modis-17A2HGF-061/MOD17A2HGF.A2021361.h10v06.061/MOD17A2HGF.A2021361.h10v06.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51010006",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -7783653.637667,
+            2223901.039333
+          ],
+          [
+            -7783653.637667,
+            3335851.559
+          ],
+          [
+            -8895604.157333,
+            3335851.559
+          ],
+          [
+            -8895604.157333,
+            2223901.039333
+          ],
+          [
+            -7783653.637667,
+            2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652749973,
+      0.0,
+      -8895604.157333,
+      0.0,
+      -463.3127165279167,
+      3335851.559
+    ],
+    "eo:cloud_cover": 86,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,52 @@
     }
   ],
   "assets": {
+    "Gpp_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637_Gpp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gross Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PsnNet_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637_PsnNet_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Net Photosynthesis",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Psn_QC_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637_Psn_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD17A2HGF.A2021361.h10v06.061.2022020134637.hdf",
       "type": "application/x-hdf",
@@ -87,6 +175,10 @@
     -74.2129537334706,
     30.0383760061888
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-17A2HGF-061"
 }

--- a/examples/modis-061/modis-17A2HGF-061/MYD17A2HGF.A2021361.h13v09.061/MYD17A2HGF.A2021361.h13v09.061.json
+++ b/examples/modis-061/modis-17A2HGF-061/MYD17A2HGF.A2021361.h13v09.061/MYD17A2HGF.A2021361.h13v09.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 13,
     "modis:vertical-tile": 9,
     "modis:tile-id": "51013009",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -4447802.078667,
+            -1111950.519667
+          ],
+          [
+            -4447802.078667,
+            0.0
+          ],
+          [
+            -5559752.598333,
+            0.0
+          ],
+          [
+            -5559752.598333,
+            -1111950.519667
+          ],
+          [
+            -4447802.078667,
+            -1111950.519667
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652750013,
+      0.0,
+      -5559752.598333,
+      0.0,
+      -463.3127165279167,
+      0.0
+    ],
+    "eo:cloud_cover": 77,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,52 @@
     }
   ],
   "assets": {
+    "Gpp_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829_Gpp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gross Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "PsnNet_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829_PsnNet_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Net Photosynthesis",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Psn_QC_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829_Psn_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD17A2HGF.A2021361.h13v09.061.2022021010829.hdf",
       "type": "application/x-hdf",
@@ -87,6 +175,10 @@
     -39.8421028844678,
     0.00432291256969055
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-17A2HGF-061"
 }

--- a/examples/modis-061/modis-17A3HGF-061/MOD17A3HGF.A2021001.h14v02.061/MOD17A3HGF.A2021001.h14v02.061.json
+++ b/examples/modis-061/modis-17A3HGF-061/MOD17A3HGF.A2021001.h14v02.061/MOD17A3HGF.A2021001.h14v02.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 14,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51014002",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -3335851.559,
+            6671703.118
+          ],
+          [
+            -3335851.559,
+            7783653.637667
+          ],
+          [
+            -4447802.078667,
+            7783653.637667
+          ],
+          [
+            -4447802.078667,
+            6671703.118
+          ],
+          [
+            -3335851.559,
+            6671703.118
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279167,
+      0.0,
+      -4447802.078667,
+      0.0,
+      -463.3127165279169,
+      7783653.637667
+    ],
+    "eo:cloud_cover": 99,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,53 @@
     }
   ],
   "assets": {
+    "Gpp_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800_Gpp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gross Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Npp_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800_Npp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Net Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Npp_QC_500m": {
+      "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800_Npp_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD17A3HGF.A2021001.h14v02.061.2022020135800.hdf",
       "type": "application/x-hdf",
@@ -87,6 +176,10 @@
     -59.4418379607338,
     70.1134921142962
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-17A3HGF-061"
 }

--- a/examples/modis-061/modis-17A3HGF-061/MYD17A3HGF.A2021001.h13v09.061/MYD17A3HGF.A2021001.h13v09.061.json
+++ b/examples/modis-061/modis-17A3HGF-061/MYD17A3HGF.A2021001.h13v09.061/MYD17A3HGF.A2021001.h13v09.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 13,
     "modis:vertical-tile": 9,
     "modis:tile-id": "51013009",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -4447802.078667,
+            -1111950.519667
+          ],
+          [
+            -4447802.078667,
+            0.0
+          ],
+          [
+            -5559752.598333,
+            0.0
+          ],
+          [
+            -5559752.598333,
+            -1111950.519667
+          ],
+          [
+            -4447802.078667,
+            -1111950.519667
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.31271652750013,
+      0.0,
+      -5559752.598333,
+      0.0,
+      -463.3127165279167,
+      0.0
+    ],
+    "eo:cloud_cover": 77,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,53 @@
     }
   ],
   "assets": {
+    "Gpp_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736_Gpp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Gross Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Npp_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736_Npp_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Net Primary Productivity",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "kg C/m^2",
+          "scale": 0.0001
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Npp_QC_500m": {
+      "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736_Npp_QC_500m.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality control",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Percent"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD17A3HGF.A2021001.h13v09.061.2022021012736.hdf",
       "type": "application/x-hdf",
@@ -87,6 +176,10 @@
     -39.8421028844678,
     0.00432291256969055
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-17A3HGF-061"
 }

--- a/examples/modis-061/modis-21A2-061/MOD21A2.A2022033.h12v08.061/MOD21A2.A2022033.h12v08.061.json
+++ b/examples/modis-061/modis-21A2-061/MOD21A2.A2022033.h12v08.061/MOD21A2.A2022033.h12v08.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51012008",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -5559752.598333,
+            0.0
+          ],
+          [
+            -5559752.598333,
+            1111950.519667
+          ],
+          [
+            -6671703.118,
+            1111950.519667
+          ],
+          [
+            -6671703.118,
+            0.0
+          ],
+          [
+            -5559752.598333,
+            0.0
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.625433055833,
+      0.0,
+      -6671703.118,
+      0.0,
+      -926.6254330558334,
+      1111950.519667
+    ],
     "eo:cloud_cover": 36,
     "datetime": null
   },
@@ -65,6 +106,173 @@
     }
   ],
   "assets": {
+    "Emis_29": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_Emis_29.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average Day/Night Band 29 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_31": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_Emis_31.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average Day/Night Band 31 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_32": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_Emis_32.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average Day/Night Band 32 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Day_1KM": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_LST_Day_1KM.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day Land Surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Night_1KM": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_LST_Night_1KM.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night Land Surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Day": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_QC_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day Quality Control",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Night": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_QC_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night Quality Control",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Angle_Day": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_View_Angle_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day view zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Angle_Night": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_View_Angle_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night view zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Time_Day": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_View_Time_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day Time of Observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Time_Night": {
+      "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733_View_Time_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night Time of Observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MOD21A2.A2022033.h12v08.061.2022042050733.hdf",
       "type": "application/x-hdf",
@@ -89,7 +297,9 @@
     10.0046098963972
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "collection": "modis-21A2-061"
 }

--- a/examples/modis-061/modis-21A2-061/MYD21A2.A2022025.h10v06.061/MYD21A2.A2022025.h10v06.061.json
+++ b/examples/modis-061/modis-21A2-061/MYD21A2.A2022025.h10v06.061/MYD21A2.A2022025.h10v06.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51010006",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -7783653.637667,
+            2223901.039333
+          ],
+          [
+            -7783653.637667,
+            3335851.559
+          ],
+          [
+            -8895604.157333,
+            3335851.559
+          ],
+          [
+            -8895604.157333,
+            2223901.039333
+          ],
+          [
+            -7783653.637667,
+            2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      1200,
+      1200
+    ],
+    "proj:transform": [
+      926.6254330549995,
+      0.0,
+      -8895604.157333,
+      0.0,
+      -926.6254330558334,
+      3335851.559
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,173 @@
     }
   ],
   "assets": {
+    "Emis_29": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_Emis_29.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average Day/Night Band 29 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_31": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_Emis_31.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average Day/Night Band 31 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Emis_32": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_Emis_32.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Average Day/Night Band 32 emissivity",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "scale": 0.002
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Day_1KM": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_LST_Day_1KM.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day Land Surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "LST_Night_1KM": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_LST_Night_1KM.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night Land Surface Temperature",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 1000,
+          "unit": "Kelvin",
+          "scale": 0.02
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Day": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_QC_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day Quality Control",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QC_Night": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_QC_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night Quality Control",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Angle_Day": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_View_Angle_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day view zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Angle_Night": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_View_Angle_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night view zenith angle",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Degree"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Time_Day": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_View_Time_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Day Time of Observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "View_Time_Night": {
+      "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054_View_Time_Night.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Night Time of Observation",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 1000,
+          "unit": "Hours",
+          "scale": 0.1
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MYD21A2.A2022025.h10v06.061.2022035072054.hdf",
       "type": "application/x-hdf",
@@ -87,6 +296,10 @@
     -74.2129537334706,
     30.0383760061888
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-21A2-061"
 }

--- a/examples/modis-061/modis-43A4-061/MCD43A4.A2022032.h14v10.061/MCD43A4.A2022032.h14v10.061.json
+++ b/examples/modis-061/modis-43A4-061/MCD43A4.A2022032.h14v10.061/MCD43A4.A2022032.h14v10.061.json
@@ -14,6 +14,47 @@
     "modis:horizontal-tile": 14,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51014010",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -3335851.559,
+            -2223901.039333
+          ],
+          [
+            -3335851.559,
+            -1111950.519667
+          ],
+          [
+            -4447802.078667,
+            -1111950.519667
+          ],
+          [
+            -4447802.078667,
+            -2223901.039333
+          ],
+          [
+            -3335851.559,
+            -2223901.039333
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279167,
+      0.0,
+      -4447802.078667,
+      0.0,
+      -463.3127165274999,
+      -1111950.519667
+    ],
     "eo:cloud_cover": 10,
     "datetime": "2022-02-01T00:00:00Z"
   },
@@ -65,6 +106,377 @@
     }
   ],
   "assets": {
+    "BRDF_Albedo_Band_Mandatory_Quality_Band1": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band1.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 1",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band1"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BRDF_Albedo_Band_Mandatory_Quality_Band2": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band2.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 2",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band2"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BRDF_Albedo_Band_Mandatory_Quality_Band3": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band3.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 3",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band3"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BRDF_Albedo_Band_Mandatory_Quality_Band4": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band4.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 4",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band4"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BRDF_Albedo_Band_Mandatory_Quality_Band5": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band5.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 5",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band5"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BRDF_Albedo_Band_Mandatory_Quality_Band6": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band6.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 6",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band6"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "BRDF_Albedo_Band_Mandatory_Quality_Band7": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_BRDF_Albedo_Band_Mandatory_Quality_Band7.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "BRDF Albedo Mandatory Quality for Band 7",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "BRDF_Albedo_Band_Mandatory_Quality_Band7"
+        }
+      ],
+      "classification:classes": [
+        {
+          "value": 0,
+          "description": "Processed, good quality (full BRDF inversions)"
+        },
+        {
+          "value": 1,
+          "description": "Processed, see other QA (magnitude BRDF inversions)"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Nadir_Reflectance_Band1": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band1.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 1",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band1",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "Nadir_Reflectance_Band2": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band2.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 2",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band2",
+          "common_name": "nir08",
+          "center_wavelength": 0.8585,
+          "full_width_half_max": 0.35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "Nadir_Reflectance_Band3": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band3.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 3",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band3",
+          "common_name": "blue",
+          "center_wavelength": 0.469,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "Nadir_Reflectance_Band4": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band4.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 4",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band4",
+          "common_name": "green",
+          "center_wavelength": 0.555,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "Nadir_Reflectance_Band5": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band5.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 5",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band5",
+          "common_name": "lwir12",
+          "center_wavelength": 1.24,
+          "full_width_half_max": 0.2
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "Nadir_Reflectance_Band6": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band6.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 6",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band6",
+          "common_name": "swir16",
+          "center_wavelength": 1.64,
+          "full_width_half_max": 0.24
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "Nadir_Reflectance_Band7": {
+      "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831_Nadir_Reflectance_Band7.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "NBAR at local solar noon for Band 7",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "scale": 0.0001
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Nadir_Reflectance_Band7",
+          "common_name": "swir22",
+          "center_wavelength": 2.13,
+          "full_width_half_max": 0.5
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MCD43A4.A2022032.h14v10.061.2022041051831.hdf",
       "type": "application/x-hdf",
@@ -89,7 +501,10 @@
     -9.95544626171462
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
   ],
   "collection": "modis-43A4-061"
 }

--- a/examples/modis-061/modis-64A1-061/MCD64A1.A2021335.h10v06.061/MCD64A1.A2021335.h10v06.061.json
+++ b/examples/modis-061/modis-64A1-061/MCD64A1.A2021335.h10v06.061/MCD64A1.A2021335.h10v06.061.json
@@ -14,6 +14,48 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51010006",
+    "proj:epsg": null,
+    "proj:wkt2": "PROJCRS[\"unnamed\",BASEGEOGCRS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",ELLIPSOID[\"Custom spheroid\",6371007.181,0,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433,ID[\"EPSG\",9122]]]],CONVERSION[\"unnamed\",METHOD[\"Sinusoidal\"],PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"easting\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"northing\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]",
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -7783653.637661,
+            2223901.03933
+          ],
+          [
+            -7783653.637661,
+            3335851.558997
+          ],
+          [
+            -8895604.157328,
+            3335851.558997
+          ],
+          [
+            -8895604.157328,
+            2223901.03933
+          ],
+          [
+            -7783653.637661,
+            2223901.03933
+          ]
+        ]
+      ]
+    },
+    "proj:shape": [
+      2400,
+      2400
+    ],
+    "proj:transform": [
+      463.3127165279169,
+      0.0,
+      -8895604.157328,
+      0.0,
+      -463.3127165279167,
+      3335851.558997
+    ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -64,6 +106,80 @@
     }
   ],
   "assets": {
+    "Burn_Date": {
+      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453_Burn_Date.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Burn day of year",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Day"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Burn_Date_Uncertainty": {
+      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453_Burn_Date_Uncertainty.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Estimated uncertainty in burn day",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500,
+          "unit": "Day"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "First_Day": {
+      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453_First_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "First day of the year of reliable change detection",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Day"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "Last_Day": {
+      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453_Last_Day.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Last day of the year of reliable change detection",
+      "raster:bands": [
+        {
+          "data_type": "int16",
+          "spatial_resolution": 500,
+          "unit": "Day"
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "QA": {
+      "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453_QA.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "Quality Assurance Indicators",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 500
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
     "hdf": {
       "href": "../../../../tests/data-files/external/MCD64A1.A2021335.h10v06.061.2022035055453.hdf",
       "type": "application/x-hdf",
@@ -87,6 +203,10 @@
     -74.2129537335,
     30.0383760062
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
   "collection": "modis-64A1-061"
 }

--- a/src/stactools/modis/builder.py
+++ b/src/stactools/modis/builder.py
@@ -270,7 +270,7 @@ class ModisBuilder(RasterioBuilder):
         """
         assert self.metadata
         item_info = super().item_info(id)
-        if self.metadata.qa_percent_not_produced_cloud:
+        if self.metadata.qa_percent_not_produced_cloud is not None:
             item_info.eo = {"cloud_cover": self.metadata.qa_percent_not_produced_cloud}
         return item_info
 
@@ -289,7 +289,10 @@ class ModisBuilder(RasterioBuilder):
         if asset_info is None:
             return None
 
-        if self.metadata.qa_percent_cloud_cover:
+        if (
+            self.metadata.qa_percent_cloud_cover
+            and self.metadata.qa_percent_cloud_cover.get(key, None)
+        ):
             asset_info.eo = {"cloud_cover": self.metadata.qa_percent_cloud_cover[key]}
 
         band = self.bands().get(key)

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -162,8 +162,11 @@ class Metadata:
             if band_qa_percent_cloud_cover:
                 qa_percent_cloud_cover[name] = int(band_qa_percent_cloud_cover)
 
-        if qa_percent_cloud_cover and not qa_percent_not_produced_cloud:
-            assert len(set(qa_percent_cloud_cover.values())) == 1
+        if qa_percent_cloud_cover and qa_percent_not_produced_cloud is None:
+            assert len(set(qa_percent_cloud_cover.values())) == 1, (
+                f"Mutiple, different 'qa_percent_cloud_cover' values exist "
+                f"in href={href}. This is not supported at this time."
+            )
             qa_percent_not_produced_cloud = next(iter(qa_percent_cloud_cover.values()))
 
         platform_elements = metadata.findall("Platform")

--- a/src/stactools/modis/metadata.py
+++ b/src/stactools/modis/metadata.py
@@ -157,10 +157,14 @@ class Metadata:
                 "ParameterName", missing_element("ParameterName")
             ).replace(" ", "_")
             band_qa_percent_cloud_cover = measured_parameter.find_text(
-                "QAPercentCloudCover"
+                "QAStats/QAPercentCloudCover"
             )
-            if qa_percent_cloud_cover:
+            if band_qa_percent_cloud_cover:
                 qa_percent_cloud_cover[name] = int(band_qa_percent_cloud_cover)
+
+        if qa_percent_cloud_cover and not qa_percent_not_produced_cloud:
+            assert len(set(qa_percent_cloud_cover.values())) == 1
+            qa_percent_not_produced_cloud = next(iter(qa_percent_cloud_cover.values()))
 
         platform_elements = metadata.findall("Platform")
         platforms = [

--- a/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006/MCD12Q1.A2001001.h00v08.006.json
+++ b/tests/data-files/expected/MCD12Q1/006/MCD12Q1.A2001001.h00v08.006/MCD12Q1.A2001001.h00v08.006.json
@@ -128,6 +128,7 @@
     "modis:horizontal-tile": 0,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51000008",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -227,6 +228,8 @@
     -169.920147,
     9.998978
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-12Q1-006"
 }

--- a/tests/data-files/expected/MCD15A2H/061/MCD15A2H.A2022025.h01v11.061/MCD15A2H.A2022025.h01v11.061.json
+++ b/tests/data-files/expected/MCD15A2H/061/MCD15A2H.A2022025.h01v11.061/MCD15A2H.A2022025.h01v11.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 1,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51001011",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -113,6 +114,8 @@
     -169.997993708017,
     -19.9296251074518
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-15A2H-061"
 }

--- a/tests/data-files/expected/MCD15A3H/061/MCD15A3H.A2022033.h12v10.061/MCD15A3H.A2022033.h12v10.061.json
+++ b/tests/data-files/expected/MCD15A3H/061/MCD15A3H.A2022033.h12v10.061/MCD15A3H.A2022033.h12v10.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51012010",
+    "eo:cloud_cover": 39,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -50.5717093742954,
     -9.95174301126409
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-15A3H-061"
 }

--- a/tests/data-files/expected/MCD64A1/061/MCD64A1.A2021335.h10v06.061/MCD64A1.A2021335.h10v06.061.json
+++ b/tests/data-files/expected/MCD64A1/061/MCD64A1.A2021335.h10v06.061/MCD64A1.A2021335.h10v06.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51010006",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -74.2129537335,
     30.0383760062
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-64A1-061"
 }

--- a/tests/data-files/expected/MOD09A1/061/MOD09A1.A2022033.h19v10.061/MOD09A1.A2022033.h19v10.061.json
+++ b/tests/data-files/expected/MOD09A1/061/MOD09A1.A2022033.h19v10.061/MOD09A1.A2022033.h19v10.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 19,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51019010",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     21.2909979394424,
     -9.95885098058137
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-09A1-061"
 }

--- a/tests/data-files/expected/MOD09Q1/061/MOD09Q1.A2022033.h10v10.061/MOD09Q1.A2022033.h10v10.061.json
+++ b/tests/data-files/expected/MOD09Q1/061/MOD09Q1.A2022033.h10v10.061/MOD09Q1.A2022033.h10v10.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51010010",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -70.8054833864951,
     -9.94789001665572
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-09Q1-061"
 }

--- a/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006/MOD10A1.A2022029.h10v05.006.json
+++ b/tests/data-files/expected/MOD10A1/006/MOD10A1.A2022029.h10v05.006/MOD10A1.A2022029.h10v05.006.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51010005",
+    "eo:cloud_cover": 4,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -80.5775666708921,
     40.0637836759185
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A1-006"
 }

--- a/tests/data-files/expected/MOD10A1/061/MOD10A1.A2022040.h11v05.061/MOD10A1.A2022040.h11v05.061.json
+++ b/tests/data-files/expected/MOD10A1/061/MOD10A1.A2022040.h11v05.061/MOD10A1.A2022040.h11v05.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51011005",
+    "eo:cloud_cover": 24,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -69.0368143977928,
     40.0539543997624
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A1-061"
 }

--- a/tests/data-files/expected/MOD10A2/061/MOD10A2.A2022033.h09v05.061/MOD10A2.A2022033.h09v05.061.json
+++ b/tests/data-files/expected/MOD10A2/061/MOD10A2.A2022033.h09v05.061/MOD10A2.A2022033.h09v05.061.json
@@ -55,6 +55,7 @@
       -463.3127165279167,
       4447802.078667
     ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -200,6 +201,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/classification/v1.0.0/schema.json"
   ],

--- a/tests/data-files/expected/MOD13A1.A2022081.h09v05.006.2022101145817_BR_B06_cropped.json
+++ b/tests/data-files/expected/MOD13A1.A2022081.h09v05.006.2022101145817_BR_B06_cropped.json
@@ -53,6 +53,7 @@
       -463.3127165279167,
       3892290.131550028
     ],
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -108,6 +109,7 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ]
 }

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "eo:cloud_cover": 5,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13A1-006"
 }

--- a/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
+++ b/tests/data-files/expected/MOD13A1/006/MOD13A1.A2022001.h09v05.006/MOD13A1.A2022001.h09v05.006.json
@@ -14,7 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
-    "eo:cloud_cover": 5,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13A1/061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
+++ b/tests/data-files/expected/MOD13A1/061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
@@ -14,7 +14,7 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51012011",
-    "eo:cloud_cover": 1,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13A1/061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
+++ b/tests/data-files/expected/MOD13A1/061/MOD13A1.A2022017.h12v11.061/MOD13A1.A2022017.h12v11.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51012011",
+    "eo:cloud_cover": 1,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -52.9919478058681,
     -19.9038664997372
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13A1-061"
 }

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
@@ -55,7 +55,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
-    "eo:cloud_cover": 5,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
+++ b/tests/data-files/expected/MOD13Q1/006/MOD13Q1.A2022001.h09v05.006/MOD13Q1.A2022001.h09v05.006.json
@@ -55,6 +55,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "eo:cloud_cover": 5,
     "datetime": null
   },
   "geometry": {
@@ -128,6 +129,8 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13Q1-006"
 }

--- a/tests/data-files/expected/MOD13Q1/061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
+++ b/tests/data-files/expected/MOD13Q1/061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
@@ -14,7 +14,7 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51012011",
-    "eo:cloud_cover": 1,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/tests/data-files/expected/MOD13Q1/061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
+++ b/tests/data-files/expected/MOD13Q1/061/MOD13Q1.A2022017.h12v11.061/MOD13Q1.A2022017.h12v11.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 12,
     "modis:vertical-tile": 11,
     "modis:tile-id": "51012011",
+    "eo:cloud_cover": 1,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -52.9919478058681,
     -19.9038664997372
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13Q1-061"
 }

--- a/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006/MOD15A2H.A2022017.h10v05.006.json
+++ b/tests/data-files/expected/MOD15A2H/006/MOD15A2H.A2022017.h10v05.006/MOD15A2H.A2022017.h10v05.006.json
@@ -29,6 +29,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51010005",
+    "eo:cloud_cover": 9,
     "datetime": null
   },
   "geometry": {
@@ -102,6 +103,8 @@
     -80.5775666708921,
     40.0637836759185
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-15A2H-006"
 }

--- a/tests/data-files/expected/MOD15A2H/061/MOD15A2H.A2022033.h13v10.061/MOD15A2H.A2022033.h13v10.061.json
+++ b/tests/data-files/expected/MOD15A2H/061/MOD15A2H.A2022033.h13v10.061/MOD15A2H.A2022033.h13v10.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 13,
     "modis:vertical-tile": 10,
     "modis:tile-id": "51013010",
+    "eo:cloud_cover": 29,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -40.4553463288051,
     -9.95361312745358
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-15A2H-061"
 }

--- a/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006/MOD16A3GF.A2020001.h09v04.006.json
+++ b/tests/data-files/expected/MOD16A3GF/006/MOD16A3GF.A2020001.h09v04.006/MOD16A3GF.A2020001.h09v04.006.json
@@ -35,6 +35,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -108,6 +109,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-16A3GF-006"
 }

--- a/tests/data-files/expected/MOD16A3GF/061/MOD16A3GF.A2021001.h11v02.061/MOD16A3GF.A2021001.h11v02.061.json
+++ b/tests/data-files/expected/MOD16A3GF/061/MOD16A3GF.A2021001.h11v02.061/MOD16A3GF.A2021001.h11v02.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51011002",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -113,6 +114,8 @@
     -109.906882828253,
     75.55535641397
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-16A3GF-061"
 }

--- a/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006/MOD17A2H.A2022017.h09v04.006.json
+++ b/tests/data-files/expected/MOD17A2H/006/MOD17A2H.A2022017.h09v04.006/MOD17A2H.A2022017.h09v04.006.json
@@ -36,6 +36,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 70,
     "datetime": null
   },
   "geometry": {
@@ -109,6 +110,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2H-006"
 }

--- a/tests/data-files/expected/MOD17A2H/061/MOD17A2H.A2022025.h08v05.061/MOD17A2H.A2022025.h08v05.061.json
+++ b/tests/data-files/expected/MOD17A2H/061/MOD17A2H.A2022025.h08v05.061/MOD17A2H.A2022025.h08v05.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 8,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51008005",
+    "eo:cloud_cover": 59,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -103.699828723654,
     40.0852255853565
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2H-061"
 }

--- a/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006/MOD17A2HGF.A2021337.h09v05.006.json
+++ b/tests/data-files/expected/MOD17A2HGF/006/MOD17A2HGF.A2021337.h09v05.006/MOD17A2HGF.A2021337.h09v05.006.json
@@ -36,6 +36,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51009005",
+    "eo:cloud_cover": 22,
     "datetime": null
   },
   "geometry": {
@@ -109,6 +110,8 @@
     -92.131858571552,
     40.0742066197196
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2HGF-006"
 }

--- a/tests/data-files/expected/MOD17A2HGF/061/MOD17A2HGF.A2021361.h10v06.061/MOD17A2HGF.A2021361.h10v06.061.json
+++ b/tests/data-files/expected/MOD17A2HGF/061/MOD17A2HGF.A2021361.h10v06.061/MOD17A2HGF.A2021361.h10v06.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51010006",
+    "eo:cloud_cover": 86,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -74.2129537334706,
     30.0383760061888
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2HGF-061"
 }

--- a/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006/MOD17A3HGF.A2020001.h09v04.006.json
+++ b/tests/data-files/expected/MOD17A3HGF/006/MOD17A3HGF.A2020001.h09v04.006/MOD17A3HGF.A2020001.h09v04.006.json
@@ -28,6 +28,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 75,
     "datetime": null
   },
   "geometry": {
@@ -101,6 +102,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A3HGF-006"
 }

--- a/tests/data-files/expected/MOD17A3HGF/061/MOD17A3HGF.A2021001.h14v02.061/MOD17A3HGF.A2021001.h14v02.061.json
+++ b/tests/data-files/expected/MOD17A3HGF/061/MOD17A3HGF.A2021001.h14v02.061/MOD17A3HGF.A2021001.h14v02.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 14,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51014002",
+    "eo:cloud_cover": 99,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -59.4418379607338,
     70.1134921142962
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A3HGF-061"
 }

--- a/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006/MOD44B.A2020065.h09v04.006.json
+++ b/tests/data-files/expected/MOD44B/006/MOD44B.A2020065.h09v04.006/MOD44B.A2020065.h09v04.006.json
@@ -30,6 +30,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51009004",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -103,6 +104,8 @@
     -104.235445821904,
     50.1159178280076
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-44B-006"
 }

--- a/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006/MOD44W.A2015001.h10v04.006.json
+++ b/tests/data-files/expected/MOD44W/006/MOD44W.A2015001.h10v04.006/MOD44W.A2015001.h10v04.006.json
@@ -26,6 +26,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51010004",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -99,6 +100,8 @@
     -91.190961,
     50.104685
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-44W-006"
 }

--- a/tests/data-files/expected/MYD09A1/061/MYD09A1.A2022025.h09v08.061/MYD09A1.A2022025.h09v08.061.json
+++ b/tests/data-files/expected/MYD09A1/061/MYD09A1.A2022025.h09v08.061/MYD09A1.A2022025.h09v08.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51009008",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -79.6923787161652,
     10.0071017643835
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-09A1-061"
 }

--- a/tests/data-files/expected/MYD09Q1/061/MYD09Q1.A2022025.h02v08.061/MYD09Q1.A2022025.h02v08.061.json
+++ b/tests/data-files/expected/MYD09Q1/061/MYD09Q1.A2022025.h02v08.061/MYD09Q1.A2022025.h02v08.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 2,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51002008",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -149.430892222897,
     10.0131469004655
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-09Q1-061"
 }

--- a/tests/data-files/expected/MYD10A1/061/MYD10A1.A2022043.h21v04.061/MYD10A1.A2022043.h21v04.061.json
+++ b/tests/data-files/expected/MYD10A1/061/MYD10A1.A2022043.h21v04.061/MYD10A1.A2022043.h21v04.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 21,
     "modis:vertical-tile": 4,
     "modis:tile-id": "51021004",
+    "eo:cloud_cover": 61,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     62.2504323634995,
     50.0432112964703
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A1-061"
 }

--- a/tests/data-files/expected/MYD10A2/061/MYD10A2.A2022025.h10v05.061/MYD10A2.A2022025.h10v05.061.json
+++ b/tests/data-files/expected/MYD10A2/061/MYD10A2.A2022025.h10v05.061/MYD10A2.A2022025.h10v05.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 5,
     "modis:tile-id": "51010005",
+    "eo:cloud_cover": 1,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -80.5775666708921,
     40.0637836759185
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-10A2-061"
 }

--- a/tests/data-files/expected/MYD13A1/061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
+++ b/tests/data-files/expected/MYD13A1/061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 25,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51025002",
+    "eo:cloud_cover": 46,
     "datetime": null
   },
   "geometry": {
@@ -113,6 +114,8 @@
     -176.534172118079,
     69.2113905326394
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13A1-061"
 }

--- a/tests/data-files/expected/MYD13A1/061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
+++ b/tests/data-files/expected/MYD13A1/061/MYD13A1.A2022009.h25v02.061/MYD13A1.A2022009.h25v02.061.json
@@ -14,7 +14,7 @@
     "modis:horizontal-tile": 25,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51025002",
-    "eo:cloud_cover": 46,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/tests/data-files/expected/MYD13Q1/061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
+++ b/tests/data-files/expected/MYD13Q1/061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
@@ -14,7 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51009006",
-    "eo:cloud_cover": 2,
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {

--- a/tests/data-files/expected/MYD13Q1/061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
+++ b/tests/data-files/expected/MYD13Q1/061/MYD13Q1.A2022009.h09v06.061/MYD13Q1.A2022009.h09v06.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 9,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51009006",
+    "eo:cloud_cover": 2,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -84.8251194107616,
     30.0438375723808
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-13Q1-061"
 }

--- a/tests/data-files/expected/MYD15A2H/061/MYD15A2H.A2022025.h22v08.061/MYD15A2H.A2022025.h22v08.061.json
+++ b/tests/data-files/expected/MYD15A2H/061/MYD15A2H.A2022025.h22v08.061/MYD15A2H.A2022025.h22v08.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 22,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51022008",
+    "eo:cloud_cover": 2,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     50.7804337536263,
     10.0038388277022
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-15A2H-061"
 }

--- a/tests/data-files/expected/MYD16A3GF/061/MYD16A3GF.A2021001.h11v02.061/MYD16A3GF.A2021001.h11v02.061.json
+++ b/tests/data-files/expected/MYD16A3GF/061/MYD16A3GF.A2021001.h11v02.061/MYD16A3GF.A2021001.h11v02.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 11,
     "modis:vertical-tile": 2,
     "modis:tile-id": "51011002",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -113,6 +114,8 @@
     -109.906882828253,
     75.55535641397
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-16A3GF-061"
 }

--- a/tests/data-files/expected/MYD17A2H/061/MYD17A2H.A2022025.h22v08.061/MYD17A2H.A2022025.h22v08.061.json
+++ b/tests/data-files/expected/MYD17A2H/061/MYD17A2H.A2022025.h22v08.061/MYD17A2H.A2022025.h22v08.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 22,
     "modis:vertical-tile": 8,
     "modis:tile-id": "51022008",
+    "eo:cloud_cover": 40,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     50.7804337536263,
     10.0038388277022
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2H-061"
 }

--- a/tests/data-files/expected/MYD17A2HGF/061/MYD17A2HGF.A2021361.h13v09.061/MYD17A2HGF.A2021361.h13v09.061.json
+++ b/tests/data-files/expected/MYD17A2HGF/061/MYD17A2HGF.A2021361.h13v09.061/MYD17A2HGF.A2021361.h13v09.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 13,
     "modis:vertical-tile": 9,
     "modis:tile-id": "51013009",
+    "eo:cloud_cover": 77,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -39.8421028844678,
     0.00432291256969055
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A2HGF-061"
 }

--- a/tests/data-files/expected/MYD17A3HGF/061/MYD17A3HGF.A2021001.h13v09.061/MYD17A3HGF.A2021001.h13v09.061.json
+++ b/tests/data-files/expected/MYD17A3HGF/061/MYD17A3HGF.A2021001.h13v09.061/MYD17A3HGF.A2021001.h13v09.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 13,
     "modis:vertical-tile": 9,
     "modis:tile-id": "51013009",
+    "eo:cloud_cover": 77,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -39.8421028844678,
     0.00432291256969055
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-17A3HGF-061"
 }

--- a/tests/data-files/expected/MYD21A2/061/MYD21A2.A2022025.h10v06.061/MYD21A2.A2022025.h10v06.061.json
+++ b/tests/data-files/expected/MYD21A2/061/MYD21A2.A2022025.h10v06.061/MYD21A2.A2022025.h10v06.061.json
@@ -14,6 +14,7 @@
     "modis:horizontal-tile": 10,
     "modis:vertical-tile": 6,
     "modis:tile-id": "51010006",
+    "eo:cloud_cover": 0,
     "datetime": null
   },
   "geometry": {
@@ -87,6 +88,8 @@
     -74.2129537334706,
     30.0383760061888
   ],
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "collection": "modis-21A2-061"
 }


### PR DESCRIPTION
**Related Issue(s):**
- Closes #90 

**Description:** 
- Fixes bug where `eo:cloud_cover` was not assigned to the Item properties if it had a value of `0`.
- Fixes bug where `eo:cloud_cover` was not stored or assigned to those bands/parameters/assets specified in the XML.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Example STAC Catalog has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
